### PR TITLE
Removing trailing commas

### DIFF
--- a/N3.js
+++ b/N3.js
@@ -10,7 +10,7 @@ var exports = module.exports = {
   Store:        require('./lib/N3Store'),
   StreamParser: require('./lib/N3StreamParser'),
   StreamWriter: require('./lib/N3StreamWriter'),
-  Util:         require('./lib/N3Util'),
+  Util:         require('./lib/N3Util')
 };
 
 // Load submodules on first access
@@ -21,6 +21,6 @@ Object.keys(exports).forEach(function (submodule) {
     get: function () {
       delete exports[submodule];
       return exports[submodule] = globalRequire('./lib/N3' + submodule);
-    },
+    }
   });
 });

--- a/lib/N3Lexer.js
+++ b/lib/N3Lexer.js
@@ -373,7 +373,7 @@ N3Lexer.prototype = {
         self._tokenizeToEnd(callback, true);
       }
     }
-  },
+  }
 };
 
 // ## Exports

--- a/lib/N3Parser.js
+++ b/lib/N3Parser.js
@@ -248,7 +248,7 @@ N3Parser.prototype = {
       this._callback(null, { subject:   this._subject,
                              predicate: this._predicate,
                              object:    this._object,
-                             graph:     this._graph || '' });
+                             graph:     this._graph || '' });
 
     // Restore parent triple that contains the blank node.
     var triple = this._tripleStack.pop();
@@ -446,7 +446,7 @@ N3Parser.prototype = {
       this._callback(null, { subject:   subject,
                              predicate: this._predicate,
                              object:    this._object,
-                             graph:     graph || '' });
+                             graph:     graph || '' });
     return next;
   },
 
@@ -469,7 +469,7 @@ N3Parser.prototype = {
     this._callback(null, { subject:   this._subject,
                            predicate: this._predicate,
                            object:    this._object,
-                           graph:     this._graph || '' });
+                           graph:     this._graph || '' });
     return next;
   },
 

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -351,7 +351,7 @@ N3Store.prototype = {
     }
     this._entities[name] = this._entityCount++;
     return name;
-  },
+  }
 };
 
 // ## Exports

--- a/lib/N3StreamWriter.js
+++ b/lib/N3StreamWriter.js
@@ -16,7 +16,7 @@ function N3StreamWriter(options) {
   var self = this;
   var writer = new N3Writer({
     write: function (chunk, encoding, callback) { self.push(chunk); callback && callback(); },
-    end: function (callback) { self.push(null); callback && callback(); },
+    end: function (callback) { self.push(null); callback && callback(); }
   }, options);
 
   // Implement Transform methods on top of writer

--- a/lib/N3Util.js
+++ b/lib/N3Util.js
@@ -93,7 +93,7 @@ var N3Util = {
     return '"' + value +
            (/^[a-z]+(-[a-z0-9]+)*$/i.test(modifier) ? '"@'  + modifier.toLowerCase()
                                                     : '"^^' + modifier);
-  },
+  }
 };
 
 // Add the N3Util functions to the given object or its prototype

--- a/lib/N3Writer.js
+++ b/lib/N3Writer.js
@@ -240,7 +240,7 @@ N3Writer.prototype = {
     try { this._outputStream.end(singleDone); }
     // Execute the callback if it hasn't been executed
     catch (error) { singleDone && singleDone(); }
-  },
+  }
 };
 
 // Replaces a character by its escaped version


### PR DESCRIPTION
Google's closure compiler is complaining about these trailing commas:

ERROR - Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.