### PR TITLE
Single quote literals

### DIFF
--- a/lib/N3Util.js
+++ b/lib/N3Util.js
@@ -18,7 +18,7 @@ var N3Util = {
 
   // Tests whether the given entity (triple object) represents a literal in the N3 library
   isLiteral: function (entity) {
-    return entity && entity[0] === '"';
+    return entity && (entity[0] === '"' || entity[0] === "'");
   },
 
   // Tests whether the given entity (triple object) represents a blank node in the N3 library
@@ -28,7 +28,7 @@ var N3Util = {
 
   // Gets the string value of a literal in the N3 library
   getLiteralValue: function (literal) {
-    var match = /^"([^]*)"/.exec(literal);
+    var match = /^["']((?:.|\s)*)["']/.exec(literal);
     if (!match)
       throw new Error(literal + ' is not a literal');
     return match[1];

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -1314,7 +1314,7 @@ function shouldParse(parser, input) {
     var results = [];
     parser.parse(input, function (error, triple) {
       expect(error).not.to.exist;
-      if (triple)       
+      if (triple)
         results.push(triple);
       else {
         results.should.have.lengthOf(expected.length);

--- a/test/N3Parser-test.js
+++ b/test/N3Parser-test.js
@@ -43,7 +43,15 @@ describe('N3Parser', function () {
     it('should parse a triple with a literal',
       shouldParse('<a> <b> "string".',
                   ['a', 'b', '"string"']));
+                  
+    it('should parse a triple with a multi-line literal with double quotes',
+      shouldParse('<a> <b> """string\nand another string""".',
+        ['a', 'b', '"string\nand another string"']));
 
+    it('should parse a triple with a multi-line literal with single quotes',
+      shouldParse('<a> <b> \'\'\'string\nand another string\'\'\'.',
+        ['a', 'b', '"string\nand another string"']));
+        
     it('should parse a triple with a numeric literal',
       shouldParse('<a> <b> 3.0.',
                   ['a', 'b', '"3.0"^^http://www.w3.org/2001/XMLSchema#decimal']));
@@ -1306,7 +1314,7 @@ function shouldParse(parser, input) {
     var results = [];
     parser.parse(input, function (error, triple) {
       expect(error).not.to.exist;
-      if (triple)
+      if (triple)       
         results.push(triple);
       else {
         results.should.have.lengthOf(expected.length);

--- a/test/N3Util-test.js
+++ b/test/N3Util-test.js
@@ -52,8 +52,12 @@ describe('N3Util', function () {
   });
 
   describe('isLiteral', function () {
-    it('matches a literal', function () {
+    it('matches a literal with double quotes', function () {
       N3Util.isLiteral('"http://example.org/"').should.be.true;
+    });
+    
+    it('matches a literal with single quotes', function () {
+      N3Util.isLiteral('\'http://example.org/\'').should.be.true;
     });
 
     it('matches a literal with a language', function () {
@@ -116,8 +120,12 @@ describe('N3Util', function () {
   });
 
   describe('getLiteralValue', function () {
-    it('gets the value of a literal', function () {
+    it('gets the value of a literal with double quotes', function () {
       N3Util.getLiteralValue('"Mickey"').should.equal('Mickey');
+    });
+    
+    it('gets the value of a literal with single quotes', function () {
+      N3Util.getLiteralValue('\'Mouse\'').should.equal('Mouse');
     });
 
     it('gets the value of a literal with a language', function () {


### PR DESCRIPTION
It would be nice to have single quote support when extracting data in triple format (for both single and multi-line string literals). Although the parser supports this the N3Util lacks this ability and extracting data becomes difficult.

Therefore, I did some searching around to see if this should be supported and found this: http://www.w3.org/TR/turtle/#turtle-literals Then I made some minor changes and added some basic tests to see if this is feasible.

I'n not sure what you guys think so please feel free to comment on this solution.