### PR TITLE
Change interpretation of the graph parameter in the N3Store

### DIFF
--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -27,6 +27,8 @@ function N3Store(triples, options) {
   this._prefixes = Object.create(null);
   if (options && options.prefixes)
     this.addPrefixes(options.prefixes);
+  // `_defaultGraph` is the graph that is used by default for storing triples
+  this._defaultGraph = (options && options.defaultGraph) || 'http://example.org/#defaultGraph';
   if (triples)
     this.addTriples(triples);
 }
@@ -48,6 +50,10 @@ N3Store.prototype = {
         for (var predicateKey in (subject = subjects[subjectKey]))
           size += Object.keys(subject[predicateKey]).length;
     return this._size = size;
+  },
+
+  get defaultGraph() {
+    return this._defaultGraph;
   },
 
   // ## Private methods
@@ -148,7 +154,7 @@ N3Store.prototype = {
         predicate = subject.predicate, subject = subject.subject;
 
     // Find the graph that will contain the triple.
-    graph = graph || '';
+    graph = graph || this.defaultGraph;
     var graphItem = this._graphs[graph];
     // Create the graph if it doesn't exist yet.
     if (!graphItem) {
@@ -197,7 +203,7 @@ N3Store.prototype = {
     if (!predicate)
       graph = subject.graph, object = subject.object,
         predicate = subject.predicate, subject = subject.subject;
-    graph = graph || '';
+    graph = graph || this.defaultGraph;
 
     // Find internal identifiers for all components.
     var graphItem, entities = this._entities, graphs = this._graphs;
@@ -243,44 +249,55 @@ N3Store.prototype = {
   },
 
   // ### `findByIRI` finds a set of triples matching a pattern.
-  // Setting `subject`, `predicate`, or `object` to a falsy value means an _anything_ wildcard.
-  // Setting `graph` to a falsy value means the default graph.
+  // Setting `subject`, `predicate`, `object` or `graph` to a falsy value means an _anything_ wildcard.
+  // Setting `graph` to the result of store.defaultGraph means the default graph.
   findByIRI: function (subject, predicate, object, graph) {
-    graph = graph || '';
-    var graphItem = this._graphs[graph], entities = this._entities;
-
-    // If the specified graph contain no triples, there are no results.
-    if (!graphItem) return [];
-
-    // Translate IRIs to internal index keys.
-    // Optimization: if the entity doesn't exist, no triples with it exist.
-    if (subject   && !(subject   = entities[subject]))   return [];
-    if (predicate && !(predicate = entities[predicate])) return [];
-    if (object    && !(object    = entities[object]))    return [];
-
-    // Choose the optimal index, based on what fields are present
-    if (subject) {
-      if (object)
-        // If subject and object are given, the object index will be the fastest.
-        return this._findInIndex(graphItem.objects, object, subject, predicate,
-                                 'object', 'subject', 'predicate', graph);
-      else
-        // If only subject and possibly predicate are given, the subject index will be the fastest.
-        return this._findInIndex(graphItem.subjects, subject, predicate, null,
-                                 'subject', 'predicate', 'object', graph);
+    // We either loop over all graphs, or over just one selected graph.
+    var graphs, self = this;
+    if (graph) {
+      graphs = {};
+      graphs[graph] = this._graphs[graph];
     }
-    else if (predicate)
+    else {
+      graphs = this._graphs;
+    }
+
+    return Object.keys(graphs).reduce(function (quads, graphId) {
+      var graphItem = graphs[graphId], entities = self._entities, subjectId, predicateId, objectId;
+
+      // If the specified graph contain no triples, there are no results.
+      if (!graphItem) return quads;
+
+      // Translate IRIs to internal index keys.
+      // Optimization: if the entity doesn't exist, no triples with it exist.
+      if (subject && !(subjectId = entities[subject]))   return quads;
+      if (predicate && !(predicateId = entities[predicate])) return quads;
+      if (object && !(objectId = entities[object]))    return quads;
+
+      // Choose the optimal index, based on what fields are present
+      if (subjectId) {
+        if (objectId)
+        // If subject and object are given, the object index will be the fastest.
+          return quads.concat(self._findInIndex(graphItem.objects, objectId, subjectId, predicateId,
+              'object', 'subject', 'predicate', graphId));
+        else
+        // If only subject and possibly predicate are given, the subject index will be the fastest.
+          return quads.concat(self._findInIndex(graphItem.subjects, subjectId, predicateId, null,
+              'subject', 'predicate', 'object', graphId));
+      }
+      else if (predicateId)
       // If only predicate and possibly object are given, the predicate index will be the fastest.
-      return this._findInIndex(graphItem.predicates, predicate, object, null,
-                               'predicate', 'object', 'subject', graph);
-    else if (object)
+        return quads.concat(self._findInIndex(graphItem.predicates, predicateId, objectId, null,
+            'predicate', 'object', 'subject', graphId));
+      else if (objectId)
       // If only object is given, the object index will be the fastest.
-      return this._findInIndex(graphItem.objects, object, null, null,
-                               'object', 'subject', 'predicate', graph);
-    else
+        return quads.concat(self._findInIndex(graphItem.objects, objectId, null, null,
+            'object', 'subject', 'predicate', graphId));
+      else
       // If nothing is given, iterate subjects and predicates first
-      return this._findInIndex(graphItem.subjects, null, null, null,
-                               'subject', 'predicate', 'object', graph);
+        return quads.concat(self._findInIndex(graphItem.subjects, null, null, null,
+            'subject', 'predicate', 'object', graphId));
+    }, []);
   },
 
   // ### `count` returns the number of triples matching a pattern, expanding prefixes as necessary.
@@ -300,7 +317,7 @@ N3Store.prototype = {
   // Setting `subject`, `predicate`, or `object` to `null` means an _anything_ wildcard.
   // Setting `graph` to `null` means the default graph.
   countByIRI: function (subject, predicate, object, graph) {
-    graph = graph || '';
+    graph = graph || this.defaultGraph;
     var graphItem = this._graphs[graph], entities = this._entities;
 
     // If the specified graph contain no triples, there are no results.

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -262,42 +262,44 @@ N3Store.prototype = {
       graphs = this._graphs;
     }
 
-    return Object.keys(graphs).reduce(function (quads, graphId) {
+    var quads = [];
+    for (var graphId in graphs) {
       var graphItem = graphs[graphId], entities = self._entities, subjectId, predicateId, objectId;
 
       // If the specified graph contain no triples, there are no results.
-      if (!graphItem) return quads;
+      if (!graphItem) continue; // eslint-disable-line no-continue
 
       // Translate IRIs to internal index keys.
       // Optimization: if the entity doesn't exist, no triples with it exist.
-      if (subject && !(subjectId = entities[subject]))   return quads;
-      if (predicate && !(predicateId = entities[predicate])) return quads;
-      if (object && !(objectId = entities[object]))    return quads;
+      if (subject && !(subjectId = entities[subject]))   continue; // eslint-disable-line no-continue
+      if (predicate && !(predicateId = entities[predicate])) continue; // eslint-disable-line no-continue
+      if (object && !(objectId = entities[object]))    continue; // eslint-disable-line no-continue
 
       // Choose the optimal index, based on what fields are present
       if (subjectId) {
         if (objectId)
         // If subject and object are given, the object index will be the fastest.
-          return quads.concat(self._findInIndex(graphItem.objects, objectId, subjectId, predicateId,
+          quads.push(self._findInIndex(graphItem.objects, objectId, subjectId, predicateId,
               'object', 'subject', 'predicate', graphId));
         else
         // If only subject and possibly predicate are given, the subject index will be the fastest.
-          return quads.concat(self._findInIndex(graphItem.subjects, subjectId, predicateId, null,
+          quads.push(self._findInIndex(graphItem.subjects, subjectId, predicateId, null,
               'subject', 'predicate', 'object', graphId));
       }
       else if (predicateId)
       // If only predicate and possibly object are given, the predicate index will be the fastest.
-        return quads.concat(self._findInIndex(graphItem.predicates, predicateId, objectId, null,
+        quads.push(self._findInIndex(graphItem.predicates, predicateId, objectId, null,
             'predicate', 'object', 'subject', graphId));
       else if (objectId)
       // If only object is given, the object index will be the fastest.
-        return quads.concat(self._findInIndex(graphItem.objects, objectId, null, null,
+        quads.push(self._findInIndex(graphItem.objects, objectId, null, null,
             'object', 'subject', 'predicate', graphId));
       else
       // If nothing is given, iterate subjects and predicates first
-        return quads.concat(self._findInIndex(graphItem.subjects, null, null, null,
+        quads.push(self._findInIndex(graphItem.subjects, null, null, null,
             'subject', 'predicate', 'object', graphId));
-    }, []);
+    }
+    return quads.length === 1 ? quads[0] : [].concat.apply([], quads);
   },
 
   // ### `count` returns the number of triples matching a pattern, expanding prefixes as necessary.

--- a/perf/N3Store-perf.js
+++ b/perf/N3Store-perf.js
@@ -5,25 +5,26 @@ var assert = require('assert');
 console.log('N3Store performance test');
 
 var TEST;
-var dim = parseInt(process.argv[2], 10) || 256;
+var dim = parseInt(process.argv[2], 10) || 75; // Consumes about 1GB for the quad case
 var dimSquared = dim * dim;
 var dimCubed = dimSquared * dim;
+var dimTesseracted = dimCubed * dim;
 var prefix = 'http://example.org/#';
 
+/* Test triples in default graph */
 var store = new N3.Store();
-
-TEST = '- Adding ' + dimCubed + ' triples';
+TEST = '- Adding ' + dimCubed + ' triples in the default graph';
 console.time(TEST);
-var i, j, k;
+var i, j, k, l;
 for (i = 0; i < dim; i++)
   for (j = 0; j < dim; j++)
     for (k = 0; k < dim; k++)
       store.addTriple(prefix + i, prefix + j, prefix + k);
 console.timeEnd(TEST);
 
-console.log('* Memory usage: ' + Math.round(process.memoryUsage().rss / 1024 / 1024) + 'MB');
+console.log('* Memory usage for triples: ' + Math.round(process.memoryUsage().rss / 1024 / 1024) + 'MB');
 
-TEST = '- Finding all ' + dimCubed + ' triples ' + dimSquared * 3 + ' times';
+TEST = '- Finding all ' + dimCubed + ' triples in the default graph ' + dimSquared * 3 + ' times';
 console.time(TEST);
 for (i = 0; i < dim; i++)
   assert.equal(store.find(prefix + i, null, null).length, dimSquared);
@@ -31,4 +32,31 @@ for (j = 0; j < dim; j++)
   assert.equal(store.find(null, prefix + j, null).length, dimSquared);
 for (k = 0; k < dim; k++)
   assert.equal(store.find(null, null, prefix + k).length, dimSquared);
+console.timeEnd(TEST);
+
+console.log('');
+
+/* Test quads */
+store = new N3.Store();
+TEST = '- Adding ' + dimTesseracted + ' quads';
+console.time(TEST);
+for (i = 0; i < dim; i++)
+  for (j = 0; j < dim; j++)
+    for (k = 0; k < dim; k++)
+      for (l = 0; l < dim; l++)
+        store.addTriple(prefix + i, prefix + j, prefix + k, prefix + l);
+console.timeEnd(TEST);
+
+console.log('* Memory usage for quads: ' + Math.round(process.memoryUsage().rss / 1024 / 1024) + 'MB');
+
+TEST = '- Finding all ' + dimTesseracted + ' quads ' + dimCubed * 4 + ' times';
+console.time(TEST);
+for (i = 0; i < dim; i++)
+  assert.equal(store.find(prefix + i, null, null, null).length, dimCubed);
+for (j = 0; j < dim; j++)
+  assert.equal(store.find(null, prefix + j, null, null).length, dimCubed);
+for (k = 0; k < dim; k++)
+  assert.equal(store.find(null, null, prefix + k, null).length, dimCubed);
+for (l = 0; l < dim; l++)
+  assert.equal(store.find(null, null, null, prefix + l).length, dimCubed);
 console.timeEnd(TEST);

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -50,6 +50,23 @@ describe('N3Store', function () {
     });
   });
 
+  describe('An N3Store without a configured default graph', function () {
+    var store = new N3Store();
+
+    it('should have a dummy default graph', function () {
+      store.defaultGraph.should.eql('http://example.org/#defaultGraph');
+    });
+  });
+
+  describe('An N3Store with a configured default graph', function () {
+    var dg = 'http://example.org/#defaultGraph';
+    var store = new N3Store({ defaultGraph: dg });
+
+    it('should return that configured default graph', function () {
+      store.defaultGraph.should.eql(dg);
+    });
+  });
+
   describe('An N3Store with initialized with 3 elements', function () {
     var store = new N3Store([
       { subject: 's1', predicate: 'p1', object: 'o1' },
@@ -63,7 +80,7 @@ describe('N3Store', function () {
   });
 
   describe('An N3Store with 5 elements', function () {
-    var store = new N3Store();
+    var store = new N3Store({ defaultGraph: 'http://example.org/#defaultGraph' });
     store.addTriple('s1', 'p1', 'o1');
     store.addTriple({ subject: 's1', predicate: 'p1', object: 'o2' });
     store.addTriples([
@@ -77,15 +94,22 @@ describe('N3Store', function () {
     });
 
     describe('when searched without parameters', function () {
-      it('should return all items in the default graph',
+      it('should return all items',
         shouldIncludeAll(store.find(),
-                         ['s1', 'p1', 'o1'], ['s1', 'p1', 'o2'], ['s1', 'p2', 'o2'], ['s2', 'p1', 'o1']));
+                         ['s1', 'p1', 'o1', store.defaultGraph],
+                         ['s1', 'p1', 'o2', store.defaultGraph],
+                         ['s1', 'p2', 'o2', store.defaultGraph],
+                         ['s2', 'p1', 'o1', store.defaultGraph],
+                         ['s1', 'p2', 'o3', 'c4']));
     });
 
     describe('when searched with an existing subject parameter', function () {
-      it('should return all items with this subject in the default graph',
+      it('should return all items with this subject in all graphs',
         shouldIncludeAll(store.find('s1', null, null),
-                         ['s1', 'p1', 'o1'], ['s1', 'p1', 'o2'], ['s1', 'p2', 'o2']));
+                         ['s1', 'p1', 'o1', store.defaultGraph],
+                         ['s1', 'p1', 'o2', store.defaultGraph],
+                         ['s1', 'p2', 'o2', store.defaultGraph],
+                         ['s1', 'p2', 'o3', 'c4']));
     });
 
     describe('when searched with a non-existing subject parameter', function () {
@@ -99,7 +123,9 @@ describe('N3Store', function () {
     describe('when searched with an existing predicate parameter', function () {
       it('should return all items with this predicate in the default graph',
         shouldIncludeAll(store.find(null, 'p1', null),
-                         ['s1', 'p1', 'o1'], ['s1', 'p1', 'o2'], ['s2', 'p1', 'o1']));
+                         ['s1', 'p1', 'o1', store.defaultGraph],
+                         ['s1', 'p1', 'o2', store.defaultGraph],
+                         ['s2', 'p1', 'o1', store.defaultGraph]));
     });
 
     describe('when searched with a non-existing predicate parameter', function () {
@@ -108,7 +134,9 @@ describe('N3Store', function () {
 
     describe('when searched with an existing object parameter', function () {
       it('should return all items with this object in the default graph',
-        shouldIncludeAll(store.find(null, null, 'o1'), ['s1', 'p1', 'o1'], ['s2', 'p1', 'o1']));
+        shouldIncludeAll(store.find(null, null, 'o1'),
+            ['s1', 'p1', 'o1', store.defaultGraph],
+            ['s2', 'p1', 'o1', store.defaultGraph]));
     });
 
     describe('when searched with a non-existing object parameter', function () {
@@ -117,7 +145,9 @@ describe('N3Store', function () {
 
     describe('when searched with existing subject and predicate parameters', function () {
       it('should return all items with this subject and predicate in the default graph',
-        shouldIncludeAll(store.find('s1', 'p1', null), ['s1', 'p1', 'o1'], ['s1', 'p1', 'o2']));
+        shouldIncludeAll(store.find('s1', 'p1', null),
+            ['s1', 'p1', 'o1', store.defaultGraph],
+            ['s1', 'p1', 'o2', store.defaultGraph]));
     });
 
     describe('when searched with non-existing subject and predicate parameters', function () {
@@ -126,7 +156,9 @@ describe('N3Store', function () {
 
     describe('when searched with existing subject and object parameters', function () {
       it('should return all items with this subject and object in the default graph',
-        shouldIncludeAll(store.find('s1', null, 'o2'), ['s1', 'p1', 'o2'], ['s1', 'p2', 'o2']));
+        shouldIncludeAll(store.find('s1', null, 'o2'),
+            ['s1', 'p1', 'o2', store.defaultGraph],
+            ['s1', 'p2', 'o2', store.defaultGraph]));
     });
 
     describe('when searched with non-existing subject and object parameters', function () {
@@ -135,16 +167,18 @@ describe('N3Store', function () {
 
     describe('when searched with existing predicate and object parameters', function () {
       it('should return all items with this predicate and object in the default graph',
-        shouldIncludeAll(store.find(null, 'p1', 'o1'), ['s1', 'p1', 'o1'], ['s2', 'p1', 'o1']));
+        shouldIncludeAll(store.find(null, 'p1', 'o1'),
+            ['s1', 'p1', 'o1', store.defaultGraph],
+            ['s2', 'p1', 'o1', store.defaultGraph]));
     });
 
-    describe('when searched with non-existing predicate and object parameters', function () {
-      itShouldBeEmpty(store.find(null, 'p2', 'o3'));
+    describe('when searched with non-existing predicate and object parameters in the default graph', function () {
+      itShouldBeEmpty(store.find(null, 'p2', 'o3', store.defaultGraph));
     });
 
     describe('when searched with existing subject, predicate, and object parameters', function () {
       it('should return all items with this subject, predicate, and object in the default graph',
-        shouldIncludeAll(store.find('s1', 'p1', 'o1'), ['s1', 'p1', 'o1']));
+        shouldIncludeAll(store.find('s1', 'p1', 'o1'), ['s1', 'p1', 'o1', store.defaultGraph]));
     });
 
     describe('when searched with a non-existing triple', function () {
@@ -153,8 +187,11 @@ describe('N3Store', function () {
 
     describe('when searched with the default graph parameter', function () {
       it('should return all items in the default graph',
-        shouldIncludeAll(store.find(),
-                         ['s1', 'p1', 'o1'], ['s1', 'p1', 'o2'], ['s1', 'p2', 'o2'], ['s2', 'p1', 'o1']));
+        shouldIncludeAll(store.find(null, null, null, store.defaultGraph),
+                         ['s1', 'p1', 'o1', store.defaultGraph],
+                         ['s1', 'p1', 'o2', store.defaultGraph],
+                         ['s1', 'p2', 'o2', store.defaultGraph],
+                         ['s2', 'p1', 'o1', store.defaultGraph]));
     });
 
     describe('when searched with an existing non-default graph parameter', function () {
@@ -332,7 +369,10 @@ describe('N3Store', function () {
 
       it('should not contain that triple anymore',
         shouldIncludeAll(function () { return store.find(); },
-                         ['s1', 'p1', 'o2'], ['s1', 'p2', 'o2'], ['s2', 'p1', 'o1']));
+                         ['s1', 'p1', 'o2', store.defaultGraph],
+                         ['s1', 'p2', 'o2', store.defaultGraph],
+                         ['s2', 'p1', 'o1', store.defaultGraph],
+                         ['s1', 'p2', 'o3', 'c4', store.defaultGraph]));
     });
 
     describe('when removing an existing triple from a non-default graph', function () {
@@ -355,7 +395,7 @@ describe('N3Store', function () {
 
       it('should not contain those triples anymore',
         shouldIncludeAll(function () { return store.find(); },
-                         ['s1', 'p1', 'o2']));
+                         ['s1', 'p1', 'o2', store.defaultGraph]));
     });
 
     describe('when adding and removing a triple', function () {
@@ -380,29 +420,39 @@ describe('N3Store', function () {
 
     describe('should allow to query subjects with prefixes', function () {
       it('should return all triples with that subject',
-        shouldIncludeAll(store.find('a:s1', null, null),
-                         ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1'],
-                         ['http://foo.org/#s1', 'http://bar.org/p2', 'http://foo.org/#o1']));
+          shouldIncludeAll(store.find('a:s1', null, null),
+              ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', store.defaultGraph],
+              ['http://foo.org/#s1', 'http://bar.org/p2', 'http://foo.org/#o1', store.defaultGraph],
+              ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', 'http://graphs.org/#g1']));
+    });
+
+    describe('should allow to query subjects with prefixes', function () {
+      it('should return all triples with that subject in the default graph',
+          shouldIncludeAll(store.find('a:s1', null, null, store.defaultGraph),
+              ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', store.defaultGraph],
+              ['http://foo.org/#s1', 'http://bar.org/p2', 'http://foo.org/#o1', store.defaultGraph]));
     });
 
     describe('should allow to query predicates with prefixes', function () {
       it('should return all triples with that predicate',
         shouldIncludeAll(store.find(null, 'b:p1', null),
-                         ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1'],
-                         ['http://foo.org/#s2', 'http://bar.org/p1', 'http://foo.org/#o2']));
+                         ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', store.defaultGraph],
+                         ['http://foo.org/#s2', 'http://bar.org/p1', 'http://foo.org/#o2', store.defaultGraph],
+                         ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', 'http://graphs.org/#g1']));
     });
 
     describe('should allow to query objects with prefixes', function () {
       it('should return all triples with that object',
         shouldIncludeAll(store.find(null, null, 'a:o1'),
-                         ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1'],
-                         ['http://foo.org/#s1', 'http://bar.org/p2', 'http://foo.org/#o1']));
+                         ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', store.defaultGraph],
+                         ['http://foo.org/#s1', 'http://bar.org/p2', 'http://foo.org/#o1', store.defaultGraph],
+                         ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', 'http://graphs.org/#g1']));
     });
 
     describe('should allow to query graphs with prefixes', function () {
       it('should return all triples with that graph',
         shouldIncludeAll(store.find(null, null, null, 'http://graphs.org/#g1'),
-          ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', 'http://graphs.org/#g1']));
+          ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', 'http://graphs.org/#g1', store.defaultGraph]));
     });
   });
 
@@ -418,24 +468,48 @@ describe('N3Store', function () {
     store.addPrefixes({ b: 'http://bar.org/', g: 'http://graphs.org/#' });
 
     describe('should allow to query subjects with prefixes', function () {
+      it('should return all triples with that subject in the default graph',
+        shouldIncludeAll(store.find('a:s1', null, null, store.defaultGraph),
+                         ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', store.defaultGraph],
+                         ['http://foo.org/#s1', 'http://bar.org/p2', 'http://foo.org/#o1', store.defaultGraph]));
+    });
+
+    describe('should allow to query subjects with prefixes', function () {
       it('should return all triples with that subject',
-        shouldIncludeAll(store.find('a:s1', null, null),
-                         ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1'],
-                         ['http://foo.org/#s1', 'http://bar.org/p2', 'http://foo.org/#o1']));
+          shouldIncludeAll(store.find('a:s1', null, null),
+              ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', store.defaultGraph],
+              ['http://foo.org/#s1', 'http://bar.org/p2', 'http://foo.org/#o1', store.defaultGraph],
+              ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', 'http://graphs.org/#g1']));
+    });
+
+    describe('should allow to query predicates with prefixes', function () {
+      it('should return all triples with that predicate in the default graph',
+          shouldIncludeAll(store.find(null, 'b:p1', null, store.defaultGraph),
+              ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', store.defaultGraph],
+              ['http://foo.org/#s2', 'http://bar.org/p1', 'http://foo.org/#o2', store.defaultGraph]));
     });
 
     describe('should allow to query predicates with prefixes', function () {
       it('should return all triples with that predicate',
-        shouldIncludeAll(store.find(null, 'b:p1', null),
-                         ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1'],
-                         ['http://foo.org/#s2', 'http://bar.org/p1', 'http://foo.org/#o2']));
+          shouldIncludeAll(store.find(null, 'b:p1', null),
+              ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', store.defaultGraph],
+              ['http://foo.org/#s2', 'http://bar.org/p1', 'http://foo.org/#o2', store.defaultGraph],
+              ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', 'http://graphs.org/#g1']));
+    });
+
+    describe('should allow to query objects with prefixes', function () {
+      it('should return all triples with that object in the default graph',
+          shouldIncludeAll(store.find(null, null, 'a:o1', store.defaultGraph),
+              ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', store.defaultGraph],
+              ['http://foo.org/#s1', 'http://bar.org/p2', 'http://foo.org/#o1', store.defaultGraph]));
     });
 
     describe('should allow to query objects with prefixes', function () {
       it('should return all triples with that object',
         shouldIncludeAll(store.find(null, null, 'a:o1'),
-                         ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1'],
-                         ['http://foo.org/#s1', 'http://bar.org/p2', 'http://foo.org/#o1']));
+                         ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', store.defaultGraph],
+                         ['http://foo.org/#s1', 'http://bar.org/p2', 'http://foo.org/#o1', store.defaultGraph],
+                         ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', 'http://graphs.org/#g1']));
     });
 
     describe('should allow to query graphs with prefixes', function () {
@@ -456,8 +530,8 @@ describe('N3Store', function () {
     describe('should allow to query subjects without prefixes', function () {
       it('should return all triples with that subject',
         shouldIncludeAll(store.find('http://foo.org/#s1', null, null),
-                         ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1'],
-                         ['http://foo.org/#s1', 'http://bar.org/p2', 'http://foo.org/#o1']));
+                         ['http://foo.org/#s1', 'http://bar.org/p1', 'http://foo.org/#o1', store.defaultGraph],
+                         ['http://foo.org/#s1', 'http://bar.org/p2', 'http://foo.org/#o1', store.defaultGraph]));
     });
   });
 
@@ -468,7 +542,7 @@ describe('N3Store', function () {
     describe('should allow to query predicates with prefixes', function () {
       it('should return all triples with that predicate',
         shouldIncludeAll(store.find(null, 'http:b', null),
-                         ['a', 'http://www.w3.org/2006/http#b', 'c']));
+                         ['a', 'http://www.w3.org/2006/http#b', 'c', store.defaultGraph]));
     });
   });
 


### PR DESCRIPTION
Setting the `graph` parameter to a falsy value will now, just like with the other parameters, be interpreted as a wildcard.
For fetching triples within the default graph, this graph explicitly needs to be provided as parameter value.
This default graph can be found in the store in the read-only field `defaultGraph`. This can be modified by providing a defaultGraph field in the constructor of the N3Store.

I'm aware that this will break existing implementations using the N3Store, in the sense that fetches from the store without a provided graph will now return all results instead of just the default graph. 
But I think this is for the better, to also streamline this with how this will happen in QPF.