### PR TITLE
`addTriple` returns if the insertion changed the index

### DIFF
--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -55,12 +55,15 @@ N3Store.prototype = {
   // ## Private methods
 
   // ### `_addToIndex` adds a triple to a three-layered index.
+  // Returns if the index has changed, if the entry did not already exist.
   _addToIndex: function (index0, key0, key1, key2) {
     // Create layers as necessary.
     var index1 = index0[key0] || (index0[key0] = {});
     var index2 = index1[key1] || (index1[key1] = {});
     // Setting the key to _any_ value signalizes the presence of the triple.
-    index2[key2] = null;
+    var existed = key2 in index2;
+    if(!existed) index2[key2] = null;
+    return !existed;
   },
 
   // ### `_removeFromIndex` removes a triple from a three-layered index.
@@ -143,6 +146,7 @@ N3Store.prototype = {
   // ## Public methods
 
   // ### `addTriple` adds a new N3 triple to the store.
+  // Returns if the triple index has changed, if the triple did not already exist.
   addTriple: function (subject, predicate, object, graph) {
     // Shift arguments if a triple object is given instead of components
     if (!predicate)
@@ -168,12 +172,13 @@ N3Store.prototype = {
     predicate = entities[predicate] || (entities[predicate] = ++this._entityCount);
     object    = entities[object]    || (entities[object]    = ++this._entityCount);
 
-    this._addToIndex(graphItem.subjects,   subject,   predicate, object);
+    var changed = this._addToIndex(graphItem.subjects,   subject,   predicate, object);
     this._addToIndex(graphItem.predicates, predicate, object,    subject);
     this._addToIndex(graphItem.objects,    object,    subject,   predicate);
 
     // The cached triple count is now invalid.
     this._size = null;
+    return changed;
   },
 
   // ### `addTriples` adds multiple N3 triples to the store.


### PR DESCRIPTION
It now returns whether or not the triple already existed in the store.
Small convenience feature which should not have any noticable impact, since the execution of `key2 in index2` is constant.
This could be made even faster if there was a function that allowed dictionary insertions while checking if the dictionary has changed, but don't think such a function exist.

I only added the `changed` check to the `subjects` index, I don't think it is possible for these indexes to differ? If so, I can add this check to the three indexes for that graph.