### PR TITLE
Improve N3Store lookup efficiency by maintaining an inverse index

### DIFF
--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -14,7 +14,8 @@ function N3Store(triples, options) {
   // `_entities` maps entities such as `http://xmlns.com/foaf/0.1/name` to numbers.
   // This saves memory, since only the numbers have to be stored in `_graphs`.
   this._entities = Object.create(null);
-  this._entities['><'] = 0; // Dummy entry, so the first actual key is non-zero
+  // `_entitiesInverse` is the inverse mapping of `_entities`, this is to avoid expensive inverse lookups.
+  this._entitiesInverse = Object.create(null);
   this._entityCount = 0;
   // `_blankNodeIndex` is the index of the last created blank node that was automatically named
   this._blankNodeIndex = 0;
@@ -88,7 +89,7 @@ N3Store.prototype = {
   // (for instance: _subject_, _predicate_, and _object_).
   // Finally, `graph` will be the graph of the created triples.
   _findInIndex: function (index0, key0, key1, key2, name0, name1, name2, graph) {
-    var results = [], entityKeys = Object.keys(this._entities), tmp, index1, index2;
+    var results = [], entityKeys = this._entitiesInverse, tmp, index1, index2;
 
     // If a key is specified, use only that part of index 0.
     if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
@@ -169,9 +170,10 @@ N3Store.prototype = {
     // Instead, we have a separate index that maps entities to numbers,
     // which are then used as keys in the other indexes.
     var entities = this._entities;
-    subject   = entities[subject]   || (entities[subject]   = ++this._entityCount);
-    predicate = entities[predicate] || (entities[predicate] = ++this._entityCount);
-    object    = entities[object]    || (entities[object]    = ++this._entityCount);
+    var entitiesInverse = this._entitiesInverse;
+    subject   = entities[subject]   || (entities[entitiesInverse[++this._entityCount] = subject]   = this._entityCount);
+    predicate = entities[predicate] || (entities[entitiesInverse[++this._entityCount] = predicate] = this._entityCount);
+    object    = entities[object]    || (entities[entitiesInverse[++this._entityCount] = object]    = this._entityCount);
 
     var changed = this._addToIndex(graphItem.subjects,   subject,   predicate, object);
     this._addToIndex(graphItem.predicates, predicate, object,    subject);

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -89,7 +89,9 @@ N3Store.prototype = {
   // (for instance: _subject_, _predicate_, and _object_).
   // Finally, `graph` will be the graph of the created triples.
   _findInIndex: function (index0, key0, key1, key2, name0, name1, name2, graph) {
-    var results = [], entityKeys = this._entitiesInverse, tmp, index1, index2;
+    var vars = (key0 ? 1 : 0) + (key1 ? 1 : 0) + (key2 ? 1 : 0);
+    var results = [], entityKeys = (vars > 1 && !graph) ? Object.keys(this._entities) : this._entitiesInverse,
+        tmp, index1, index2;
 
     // If a key is specified, use only that part of index 0.
     if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];

--- a/perf/N3Store-perf.js
+++ b/perf/N3Store-perf.js
@@ -24,7 +24,28 @@ console.timeEnd(TEST);
 
 console.log('* Memory usage for triples: ' + Math.round(process.memoryUsage().rss / 1024 / 1024) + 'MB');
 
-TEST = '- Finding all ' + dimCubed + ' triples to the default graph ' + dimSquared * 3 + ' times';
+TEST = '- Finding all ' + dimCubed + ' triples to the default graph ' + dimSquared * 1 + ' times (0 variables)';
+console.time(TEST);
+for (i = 0; i < dim; i++)
+  for (j = 0; j < dim; j++)
+    for (k = 0; k < dim; k++)
+      assert.equal(store.find(prefix + i, prefix + j, prefix + k).length, 1);
+console.timeEnd(TEST);
+
+TEST = '- Finding all ' + dimCubed + ' triples to the default graph ' + dimSquared * 2 + ' times (1 variable)';
+console.time(TEST);
+for (i = 0; i < dim; i++)
+  for (j = 0; j < dim; j++)
+    assert.equal(store.find(prefix + i, prefix + j, null).length, dim);
+for (i = 0; i < dim; i++)
+  for (j = 0; j < dim; j++)
+    assert.equal(store.find(prefix + i, null, prefix + j).length, dim);
+for (i = 0; i < dim; i++)
+  for (j = 0; j < dim; j++)
+    assert.equal(store.find(null, prefix + i, prefix + j).length, dim);
+console.timeEnd(TEST);
+
+TEST = '- Finding all ' + dimCubed + ' triples to the default graph ' + dimSquared * 3 + ' times (2 variables)';
 console.time(TEST);
 for (i = 0; i < dim; i++)
   assert.equal(store.find(prefix + i, null, null).length, dimSquared);


### PR DESCRIPTION
This is an improvement for the lookup-speed of the `N3Store`, as discussed in https://github.com/rubensworks/N3.js/commit/87cae2914751c93fdeb8c005b6c445d002b6f446.
Apparently, `Object.keys` became more expensive since one of the newer Node versions,
so this PR avoids calling this function every time on `this._entities` when doing lookups.
Instead, a inverse-index is maintained to avoid this operation.

I ran the performance tests to compare this new approach with the old one,
and it resulted in some interesting results:

```
2 variables for lookups (a.k.a original perf tests):
NEW:
    N3Store performance test
    - Adding 16777216 triples in the default graph: 18177.111ms
    * Memory usage for triples: 831MB
    - Finding all 16777216 triples to the default graph 196608 times: 6421.472ms

    - Adding 16777216 quads: 24892.776ms
    * Memory usage for quads: 676MB
    - Finding all 16777216 quads 1048576 times: 13141.350ms

OLD:
    N3Store performance test
    - Adding 16777216 triples in the default graph: 19465.032ms
    * Memory usage for triples: 808MB
    - Finding all 16777216 triples to the default graph 196608 times: 3206.058ms

    - Adding 16777216 quads: 24860.754ms
    * Memory usage for quads: 717MB
    - Finding all 16777216 quads 1048576 times: 19608.113ms
------------------------------------------------------------------------------------
1 variable for lookup:
NEW:
    - Finding all 16777216 triples to the default graph 65536 times: 1207.522ms
OLD:
    - Finding all 16777216 triples to the default graph 65536 times: 2133.597ms
------------------------------------------------------------------------------------
0 variables for lookup:
NEW:
    - Finding all 16777216 triples to the default graph 65536 times: 92602.621ms
OLD:
    - Finding all 16777216 triples to the default graph 65536 times: 283470.831ms
```

It appears that this new approach (precalculation of inverse index) is two times *slower* than the original approach for lookups with two variables (? ? o, ? p ?, s ? ?).
When increasing the selectivity of the lookups, this new approach becomes *faster* than the old one.
The new version is twice as fast as the old version for lookups with only one variables.
And it is three times faster than the old version for lookups without variables.

Like you have said before, the efficiency strongly depends on the access patterns.
So I'm not sure if you should accept this PR, since it makes lookups slower with two variables, but faster for the rest.
Maybe we should make two versions of the `N3Store` that are optimized for different cases.
Or maybe some more elaborate solution is possible.
