### PR TITLE
Improve N3Store lookup efficiency by maintaining an inverse index

### DIFF
--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -14,7 +14,8 @@ function N3Store(triples, options) {
   // `_entities` maps entities such as `http://xmlns.com/foaf/0.1/name` to numbers.
   // This saves memory, since only the numbers have to be stored in `_graphs`.
   this._entities = Object.create(null);
-  this._entities['><'] = 0; // Dummy entry, so the first actual key is non-zero
+  // `_entitiesInverse` is the inverse mapping of `_entities`, this is to avoid expensive inverse lookups.
+  this._entitiesInverse = Object.create(null);
   this._entityCount = 0;
   // `_blankNodeIndex` is the index of the last created blank node that was automatically named
   this._blankNodeIndex = 0;
@@ -88,7 +89,7 @@ N3Store.prototype = {
   // (for instance: _subject_, _predicate_, and _object_).
   // Finally, `graph` will be the graph of the created triples.
   _findInIndex: function (index0, key0, key1, key2, name0, name1, name2, graph) {
-    var results = [], entityKeys = Object.keys(this._entities), tmp, index1, index2;
+    var results = [], entityKeys = this._entitiesInverse, tmp, index1, index2;
 
     // If a key is specified, use only that part of index 0.
     if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
@@ -169,9 +170,10 @@ N3Store.prototype = {
     // Instead, we have a separate index that maps entities to numbers,
     // which are then used as keys in the other indexes.
     var entities = this._entities;
-    subject   = entities[subject]   || (entities[subject]   = ++this._entityCount);
-    predicate = entities[predicate] || (entities[predicate] = ++this._entityCount);
-    object    = entities[object]    || (entities[object]    = ++this._entityCount);
+    var entitiesInverse = this._entitiesInverse;
+    subject   = entities[subject]   || (entities[entitiesInverse[++this._entityCount] = subject]   = this._entityCount);
+    predicate = entities[predicate] || (entities[entitiesInverse[++this._entityCount] = predicate] = this._entityCount);
+    object    = entities[object]    || (entities[entitiesInverse[++this._entityCount] = object]    = this._entityCount);
 
     var changed = this._addToIndex(graphItem.subjects,   subject,   predicate, object);
     this._addToIndex(graphItem.predicates, predicate, object,    subject);

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -14,6 +14,7 @@ function N3Store(triples, options) {
   // `_entities` maps entities such as `http://xmlns.com/foaf/0.1/name` to numbers.
   // This saves memory, since only the numbers have to be stored in `_graphs`.
   this._entities = Object.create(null);
+  this._entities['><'] = 0; // Dummy entry, so the first actual key is non-zero
   // `_entitiesInverse` is the inverse mapping of `_entities`, this is to avoid expensive inverse lookups.
   this._entitiesInverse = Object.create(null);
   this._entityCount = 0;
@@ -90,7 +91,7 @@ N3Store.prototype = {
   // Finally, `graph` will be the graph of the created triples.
   _findInIndex: function (index0, key0, key1, key2, name0, name1, name2, graph) {
     var vars = (key0 ? 1 : 0) + (key1 ? 1 : 0) + (key2 ? 1 : 0);
-    var results = [], entityKeys = (vars > 1 && !graph) ? Object.keys(this._entities) : this._entitiesInverse,
+    var results = [], entityKeys = vars > 1 ? Object.keys(this._entities) : this._entitiesInverse,
         tmp, index1, index2;
 
     // If a key is specified, use only that part of index 0.

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -89,7 +89,9 @@ N3Store.prototype = {
   // (for instance: _subject_, _predicate_, and _object_).
   // Finally, `graph` will be the graph of the created triples.
   _findInIndex: function (index0, key0, key1, key2, name0, name1, name2, graph) {
-    var results = [], entityKeys = this._entitiesInverse, tmp, index1, index2;
+    var vars = (key0 ? 1 : 0) + (key1 ? 1 : 0) + (key2 ? 1 : 0);
+    var results = [], entityKeys = (vars > 1 && !graph) ? Object.keys(this._entities) : this._entitiesInverse,
+        tmp, index1, index2;
 
     // If a key is specified, use only that part of index 0.
     if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -90,7 +90,7 @@ N3Store.prototype = {
   // (for instance: _subject_, _predicate_, and _object_).
   // Finally, `graph` will be the graph of the created triples.
   _findInIndex: function (index0, key0, key1, key2, name0, name1, name2, graph) {
-    var vars = (key0 ? 1 : 0) + (key1 ? 1 : 0) + (key2 ? 1 : 0);
+    var vars = (key0 ? 0 : 1) + (key1 ? 0 : 1) + (key2 ? 0 : 1);
     var results = [], entityKeys = vars > 1 ? Object.keys(this._entities) : this._entitiesInverse,
         tmp, index1, index2;
 

--- a/perf/N3Store-perf.js
+++ b/perf/N3Store-perf.js
@@ -24,7 +24,28 @@ console.timeEnd(TEST);
 
 console.log('* Memory usage for triples: ' + Math.round(process.memoryUsage().rss / 1024 / 1024) + 'MB');
 
-TEST = '- Finding all ' + dimCubed + ' triples to the default graph ' + dimSquared * 3 + ' times';
+TEST = '- Finding all ' + dimCubed + ' triples to the default graph ' + dimSquared * 1 + ' times (0 variables)';
+console.time(TEST);
+for (i = 0; i < dim; i++)
+  for (j = 0; j < dim; j++)
+    for (k = 0; k < dim; k++)
+      assert.equal(store.find(prefix + i, prefix + j, prefix + k).length, 1);
+console.timeEnd(TEST);
+
+TEST = '- Finding all ' + dimCubed + ' triples to the default graph ' + dimSquared * 2 + ' times (1 variable)';
+console.time(TEST);
+for (i = 0; i < dim; i++)
+  for (j = 0; j < dim; j++)
+    assert.equal(store.find(prefix + i, prefix + j, null).length, dim);
+for (i = 0; i < dim; i++)
+  for (j = 0; j < dim; j++)
+    assert.equal(store.find(prefix + i, null, prefix + j).length, dim);
+for (i = 0; i < dim; i++)
+  for (j = 0; j < dim; j++)
+    assert.equal(store.find(null, prefix + i, prefix + j).length, dim);
+console.timeEnd(TEST);
+
+TEST = '- Finding all ' + dimCubed + ' triples to the default graph ' + dimSquared * 3 + ' times (2 variables)';
 console.time(TEST);
 for (i = 0; i < dim; i++)
   assert.equal(store.find(prefix + i, null, null).length, dimSquared);


### PR DESCRIPTION
I fixed the issues from #61, lookups are significantly faster in all cases now, at the cost of a 1.2% increase in insertion times.
```
dim = 256
OLD:
    N3Store performance test
    - Adding 16777216 triples in the default graph: 20985.810ms
    * Memory usage for triples: 814MB
    - Finding all 16777216 triples to the default graph 65536 times (0 variables): 303956.190ms
    - Finding all 16777216 triples to the default graph 131072 times (1 variable): 8910.851ms
    - Finding all 16777216 triples to the default graph 196608 times (2 variables): 4105.836ms

    - Adding 16777216 quads: 27680.169ms
    * Memory usage for quads: 648MB
    - Finding all 16777216 quads 1048576 times: 20307.015ms
NEW:
    N3Store performance test
    - Adding 16777216 triples in the default graph: 21238.570ms
    * Memory usage for triples: 734MB
    - Finding all 16777216 triples to the default graph 65536 times (0 variables): 101509.681ms
    - Finding all 16777216 triples to the default graph 131072 times (1 variable): 4243.945ms
    - Finding all 16777216 triples to the default graph 196608 times (2 variables): 3401.100ms

    - Adding 16777216 quads: 26400.740ms
    * Memory usage for quads: 796MB
    - Finding all 16777216 quads 1048576 times: 19886.337ms
```