### PR TITLE
fixed querying for blank nodes in N3Store

### DIFF
--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -366,6 +366,7 @@ N3Store.prototype = {
     }
     // Add the blank node to the entities, avoiding the generation of duplicates
     this._ids[name] = ++this._id;
+    this._entities[this._id] = name;
     return name;
   },
 };

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -586,6 +586,24 @@ describe('N3Store', function () {
     });
   });
 
+  describe('An N3Store containing a blank node', function () {
+    var store = new N3Store({ defaultGraph: 'http://example.org/#defaultGraph' });
+    var b1 = store.createBlankNode();
+    store.addTriple('s1', 'p1', b1).should.be.true;
+
+    describe('when searched with more than one variable', function () {
+      it('should return a triple with the blank node as an object',
+        shouldIncludeAll(store.find(),
+                          ['s1', 'p1', b1, store.defaultGraph]));
+    });
+
+    describe('when searched with one variable', function () {
+      it('should return a triple with the blank node as an object',
+        shouldIncludeAll(store.find('s1', 'p1'),
+                         ['s1', 'p1', b1, store.defaultGraph]));
+    });
+  });
+
   describe('An N3Store', function () {
     var store = new N3Store();
 


### PR DESCRIPTION
now updating reverse index when adding blank nodes in N3Store. queries with one variable previously returned `undefined` for blank nodes. added some simple tests