### PR TITLE
adding a rudementary typescript definition file

### DIFF
--- a/lib/n3.d.ts
+++ b/lib/n3.d.ts
@@ -1,0 +1,42 @@
+
+
+declare namespace N3 {
+
+    type ErrorCallback = (err: Error, result: any) => void;
+
+    interface Dictionary {
+
+    }
+
+    interface Triple {
+        subject: string,
+        predicate: string,
+        object: string
+    }
+
+    interface Output { 
+        addTriple(subject: string, predicate: string, object: string): void;
+        addTriple(triple: Triple): void;
+        end(err: ErrorCallback, result?: any): void;
+    }
+
+    interface Options {
+        format?: string,
+        prefixes?: any
+    }
+    function Writer(options: Options): Output;
+    function Writer(fd: any, options: Options): Output;
+
+    interface StoreOutput extends Output {
+        find(subject: string, predicate: string, object: string): Triple;
+    }
+    function Store(): StoreOutput;
+
+    namespace Util {
+        function createLiteral(value: any): string;
+    }
+}
+
+declare module "n3" {
+    export = N3;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.1",
   "description": "Lightning fast, asynchronous, streaming Turtle / N3 / RDF library.",
   "author": "Ruben Verborgh <ruben.verborgh@gmail.com>",
+  "typings": "./lib/n3.d.ts",
   "keywords": [
     "turtle",
     "rdf",


### PR DESCRIPTION
I have been working on a set of [typescript](http://www.typescriptlang.org/) [definitions](http://www.typescriptlang.org/docs/handbook/writing-declaration-files.html) for N3.
I am planning on including them in [DefinitelyTyped](http://definitelytyped.org/) but I would prefer to include them in [this package](https://github.com/RubenVerborgh/N3.js/issues/new).