### PR TITLE
Move lookup of IDs to be outside graph loop in findByIRI

### DIFF
--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -273,15 +273,15 @@ N3Store.prototype = {
     else
       graphs[graph] = this._graphs[graph];
 
+    // Translate IRIs to internal index keys.
+    // Optimization: if the entity doesn't exist, no triples with it exist.
+    if (subject   && !(subjectId   = ids[subject]))   return quads;
+    if (predicate && !(predicateId = ids[predicate])) return quads;
+    if (object    && !(objectId    = ids[object]))    return quads;
+
     for (var graphId in graphs) {
       // Only if the specified graph contains triples, there can be results
       if (graphContents = graphs[graphId]) {
-        // Translate IRIs to internal index keys.
-        // Optimization: if the entity doesn't exist, no triples with it exist.
-        if (subject   && !(subjectId   = ids[subject]))   return quads;
-        if (predicate && !(predicateId = ids[predicate])) return quads;
-        if (object    && !(objectId    = ids[object]))    return quads;
-
         // Do not emit the default graph explicitly
         if (graphId === DEFAULT_GRAPH)
           graphId = '';


### PR DESCRIPTION
Results in slightly cleaner code, and is more optimal in the
case of many graphs.