### PR TITLE
N3 store perf experiment

### DIFF
--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -187,6 +187,149 @@ N3Store.prototype = {
       fn(key0);
   },
 
+  // Lookup, lookup, lookup
+  _indexSomeGivenAllKeys: function (index0, key0, key1, key2, name0, name1, name2, graph, fn) {
+    var varCount = !key0 + !key1 + !key2,
+        // depending on the number of variables, keys or reverse index are faster
+        entityKeys = varCount > 1 ? Object.keys(this._ids) : this._entities;
+
+    // It turns out that varCount is actually a count of null parameters.
+    // We always have a null parameter count of 0.
+    var entityKeys = this._entities;
+
+    // console.log('given all keys, varCount ', varCount);
+
+    // Lookup
+    if (key0 in index0) {
+      var index1 = index0[key0];
+      // Lookup
+      if (key1 in index1) {
+        var index2 = index1[key1];
+        // Lookup
+        if (key2 in index2) {
+          var entity0 = entityKeys[key0];
+          var entity1 = entityKeys[key1];
+          var entity2 = entityKeys[key2];
+          var result = { subject: '', predicate: '', object: '', graph: graph };
+          result[name0] = entity0;
+          result[name1] = entity1;
+          result[name2] = entity2;
+          // We can just return the fn result - we're not looping
+          return fn(result);
+        }
+      }
+    }
+    return false;
+  },
+
+  // Lookup, lookup, loop
+  _indexSomeGivenKey0And1: function (index0, key0, key1, name0, name1, name2, graph, fn) {
+    // var varCount = !key0 + !key1 + !key2,
+    //     // depending on the number of variables, keys or reverse index are faster
+    //     entityKeys = varCount > 1 ? Object.keys(this._ids) : this._entities;
+
+    // It turns out that varCount is actually a count of null parameters.
+    // We always have a null parameter count of 1.
+    var entityKeys = this._entities;
+
+    // console.log('given key0and1, varCount ', varCount);
+
+    // Lookup
+    if (key0 in index0) {
+      var index1 = index0[key0];
+      // Lookup
+      if (key1 in index1) {
+        var index2 = index1[key1];
+        var entity0 = entityKeys[key0];
+        var entity1 = entityKeys[key1];
+        var values = Object.keys(index2);
+        // Loop
+        for (var l = values.length - 1; l >= 0; l--) {
+          var result = { subject: '', predicate: '', object: '', graph: graph };
+          result[name0] = entity0;
+          result[name1] = entity1;
+          result[name2] = entityKeys[values[l]];
+          if (fn(result)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  },
+
+  // Lookup, loop, loop
+  _indexSomeGivenKey0: function (index0, key0, name0, name1, name2, graph, fn) {
+    // var varCount = !key0 + !key1 + !key2,
+    //     // depending on the number of variables, keys or reverse index are faster
+    //     entityKeys = varCount > 1 ? Object.keys(this._ids) : this._entities;
+
+    // It turns out that varCount is actually a count of null parameters.
+    // We always have a null parameter count of 2.
+    var entityKeys = Object.keys(this._ids);
+
+    // console.log('given key0, varCount ', varCount);
+
+    // Lookup
+    if (key0 in index0) {
+      var index1 = index0[key0];
+      var entity0 = entityKeys[key0];
+      // Loop
+      for (var key1 in index1) {
+        var index2 = index1[key1];
+        var entity1 = entityKeys[key1];
+        var values = Object.keys(index2);
+        // Loop
+        for (var l = values.length - 1; l >= 0; l--) {
+          var result = { subject: '', predicate: '', object: '', graph: graph };
+          result[name0] = entity0;
+          result[name1] = entity1;
+          result[name2] = entityKeys[values[l]];
+          if (fn(result)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  },
+
+  // Loop, loop, loop
+  _indexSomeGivenNoKeys: function (index0, name0, name1, name2, graph, fn) {
+    // var varCount = !key0 + !key1 + !key2,
+    //     // depending on the number of variables, keys or reverse index are faster
+    //     entityKeys = varCount > 1 ? Object.keys(this._ids) : this._entities;
+
+    // It turns out that varCount is actually a count of null parameters.
+    // We always have a null parameter count of 3.
+    var entityKeys = Object.keys(this._ids);
+
+    // console.log('no keys, varCount ', varCount);
+
+    // Loop
+    for (var key0 in index0) {
+      var index1 = index0[key0];
+      var entity0 = entityKeys[key0];
+      // Loop
+      for (var key1 in index1) {
+        var index2 = index1[key1];
+        var entity1 = entityKeys[key1];
+        var values = Object.keys(index2);
+        // Loop
+        for (var l = values.length - 1; l >= 0; l--) {
+          var result = { subject: '', predicate: '', object: '', graph: graph };
+          result[name0] = entity0;
+          result[name1] = entity1;
+          result[name2] = entityKeys[values[l]];
+          if (fn(result)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  },
+
   // ### `_countInIndex` counts matching triples in a three-layered index.
   // The index base is `index0` and the keys at each level are `key0`, `key1`, and `key2`.
   // Any of these keys can be undefined, which is interpreted as a wildcard.
@@ -476,7 +619,7 @@ N3Store.prototype = {
 
   someByIRI: function (fn, subject, predicate, object, graph) {
     var graphs = {}, graphContents,
-        ids = this._ids, subjectId, predicateId, objectId;
+        ids = this._ids, sid, pid, oid;
     // Either loop over all graphs, or over just one selected graph
     if (!isString(graph))
       graphs = this._graphs;
@@ -485,9 +628,9 @@ N3Store.prototype = {
 
     // Translate IRIs to internal index keys.
     // Optimization: if the entity doesn't exist, no triples with it exist.
-    if (isString(subject)   && !(subjectId   = ids[subject]))   return false;
-    if (isString(predicate) && !(predicateId = ids[predicate])) return false;
-    if (isString(object)    && !(objectId    = ids[object]))    return false;
+    if (isString(subject)   && !(sid = ids[subject]))   return false;
+    if (isString(predicate) && !(pid = ids[predicate])) return false;
+    if (isString(object)    && !(oid = ids[object]))    return false;
 
     for (var graphId in graphs) {
       // Only if the specified graph contains triples, there can be result
@@ -497,38 +640,76 @@ N3Store.prototype = {
         //   graphId = '';
 
         // Choose the optimal index, based on what fields are present
-        if (subjectId) {
-          if (objectId) {
-          // If subject and object are given, the object index will be the fastest
-            if (this._someInIndex(graphContents.objects, objectId, subjectId, predicateId,
-                                  'object', 'subject', 'predicate', graphId, fn))
-              return true;
+        // if (subjectId) {
+        //   if (objectId) {
+        //   // If subject and object are given, the object index will be the fastest
+        //     if (this._someInIndex(graphContents.objects, objectId, subjectId, predicateId,
+        //                           'object', 'subject', 'predicate', graphId, fn))
+        //       return true;
+        //   }
+        //   else
+        //     // If only subject and possibly predicate are given, the subject index will be the fastest
+        //     if (this._someInIndex(graphContents.subjects, subjectId, predicateId, null,
+        //                           'subject', 'predicate', 'object', graphId, fn))
+        //       return true;
+        // }
+        // else if (predicateId) {
+        //   // If only predicate and possibly object are given, the predicate index will be the fastest
+        //   if (this._someInIndex(graphContents.predicates, predicateId, objectId, null,
+        //                         'predicate', 'object', 'subject', graphId, fn)) {
+        //     return true;
+        //   }
+        // }
+        // else if (objectId) {
+        //   // If only object is given, the object index will be the fastest
+        //   if (this._someInIndex(graphContents.objects, objectId, null, null,
+        //                         'object', 'subject', 'predicate', graphId, fn)) {
+        //     return true;
+        //   }
+        // }
+        // else
+        // // If nothing is given, iterate subjects and predicates first
+        // if (this._someInIndex(graphContents.subjects, null, null, null,
+        //                       'subject', 'predicate', 'object', graphId, fn)) {
+        //   return true;
+        // }
+
+        if (sid) {
+          if (pid) {
+            if (oid) {
+              // s = nz : p = nz : o = nz
+              if (this._indexSomeGivenAllKeys(graphContents.subjects, sid, pid, oid, 'subject', 'predicate', 'object', graphId, fn)) return true;
+            } else {
+              // s = nz : p = nz : o = z
+              if (this._indexSomeGivenKey0And1(graphContents.subjects, sid, pid, 'subject', 'predicate', 'object', graphId, fn)) return true;
+            }
+          } else {
+            if (oid) {
+              // s = nz : p = z : o = nz
+              if (this._indexSomeGivenKey0And1(graphContents.objects, oid, sid, 'object', 'subject', 'predicate', graphId, fn)) return true;
+            } else {
+              // s = nz : p = z : o = z
+              if (this._indexSomeGivenKey0(graphContents.subjects, sid, 'subject', 'predicate', 'object', graphId, fn)) return true;
+            }
           }
-          else
-            // If only subject and possibly predicate are given, the subject index will be the fastest
-            if (this._someInIndex(graphContents.subjects, subjectId, predicateId, null,
-                                  'subject', 'predicate', 'object', graphId, fn))
-              return true;
-        }
-        else if (predicateId) {
-          // If only predicate and possibly object are given, the predicate index will be the fastest
-          if (this._someInIndex(graphContents.predicates, predicateId, objectId, null,
-                                'predicate', 'object', 'subject', graphId, fn)) {
-            return true;
+        } else {
+          if (pid) {
+            if (oid) {
+              // s = z : p = nz : o = nz
+              if (this._indexSomeGivenKey0And1(graphContents.predicates, pid, oid, 'predicate', 'object', 'subject', graphId, fn)) return true;
+            } else {
+              // s = z : p = nz : o = z
+              if (this._indexSomeGivenKey0(graphContents.predicates, pid, 'predicate', 'object', 'subject', graphId, fn)) return true;
+            }
+          } else {
+            if (oid) {
+              // s = z : p = z : o = nz
+              if (this._indexSomeGivenKey0(graphContents.objects, oid, 'object', 'subject', 'predicate', graphId, fn)) return true;
+            } else {
+              // s = z : p = z : o = z
+              if (this._indexSomeGivenNoKeys(graphContents.subjects, 'subject', 'predicate', 'object', graphId, fn)) return true;
+            }
           }
-        }
-        else if (objectId) {
-          // If only object is given, the object index will be the fastest
-          if (this._someInIndex(graphContents.objects, objectId, null, null,
-                                'object', 'subject', 'predicate', graphId, fn)) {
-            return true;
-          }
-        }
-        else
-        // If nothing is given, iterate subjects and predicates first
-        if (this._someInIndex(graphContents.subjects, null, null, null,
-                              'subject', 'predicate', 'object', graphId, fn)) {
-          return true;
         }
       }
     }

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -133,7 +133,8 @@ N3Store.prototype = {
   _someInIndex: function (index0, key0, key1, key2, name0, name1, name2, graph, fn) {
     var tmp, index1, index2, varCount = !key0 + !key1 + !key2,
         // depending on the number of variables, keys or reverse index are faster
-        entityKeys = varCount > 1 ? Object.keys(this._ids) : this._entities;
+        entityKeys = varCount > 1 ? Object.keys(this._ids) : this._entities,
+        result = { subject: '', predicate: '', object: '', graph: graph };
 
     // If a key is specified, use only that part of index 0.
     if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
@@ -151,7 +152,6 @@ N3Store.prototype = {
             var values = key2 ? (key2 in index2 ? [key2] : []) : Object.keys(index2);
             // Create triples for all items found in index 2.
             for (var l = values.length - 1; l >= 0; l--) {
-              var result = { subject: '', predicate: '', object: '', graph: graph };
               result[name0] = entity0;
               result[name1] = entity1;
               result[name2] = entityKeys[values[l]];

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -139,21 +139,19 @@ N3Store.prototype = {
     // If a key is specified, use only that part of index 0.
     if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
     for (var value0 in index0) {
-      var entity0 = entityKeys[value0];
+      result[name0] = entityKeys[value0];
 
       if (index1 = index0[value0]) {
         // If a key is specified, use only that part of index 1.
         if (key1) (tmp = index1, index1 = {})[key1] = tmp[key1];
         for (var value1 in index1) {
-          var entity1 = entityKeys[value1];
+          result[name1] = entityKeys[value1];
 
           if (index2 = index1[value1]) {
             // If a key is specified, use only that part of index 2, if it exists.
             var values = key2 ? (key2 in index2 ? [key2] : []) : Object.keys(index2);
             // Create triples for all items found in index 2.
             for (var l = values.length - 1; l >= 0; l--) {
-              result[name0] = entity0;
-              result[name1] = entity1;
               result[name2] = entityKeys[values[l]];
               if (fn(result.subject, result.predicate, result.object, result.graph)) {
                 return true;

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -674,7 +674,7 @@ N3Store.prototype = {
   },
 
   forPredicatesByIRI: function (fn, subject, object, graph) {
-    var seen = {}, ids = this._ids, graphs = this._graphs, graphContents,
+    var seen = {}, ids = this._ids, graphs = {}, graphContents,
         entityKeys = this._entities;
 
     // Either loop over all graphs, or over just one selected graph.
@@ -751,7 +751,7 @@ N3Store.prototype = {
   },
 
   forObjectsByIRI: function (fn, subject, predicate, graph) {
-    var seen = {}, ids = this._ids, graphs = this._graphs, graphContents,
+    var seen = {}, ids = this._ids, graphs = {}, graphContents,
         entityKeys = this._entities;
 
     // Either loop over all graphs, or over just one selected graph.

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -462,52 +462,61 @@ N3Store.prototype = {
     );
   },
 
-  // ### `findByIRI` finds a set of triples matching a pattern.
-  // Setting any field to `undefined` or `null` indicates a wildcard.
+  // // ### `findByIRI` finds a set of triples matching a pattern.
+  // // Setting any field to `undefined` or `null` indicates a wildcard.
+  // findByIRI: function (subject, predicate, object, graph) {
+  //   var quads = [], graphs = {}, graphContents,
+  //       ids = this._ids, subjectId, predicateId, objectId;
+  //   // Either loop over all graphs, or over just one selected graph
+  //   if (!isString(graph))
+  //     graphs = this._graphs;
+  //   else
+  //     graphs[graph] = this._graphs[graph];
+
+  //   // Translate IRIs to internal index keys.
+  //   // Optimization: if the entity doesn't exist, no triples with it exist.
+  //   if (isString(subject)   && !(subjectId   = ids[subject]))   return quads;
+  //   if (isString(predicate) && !(predicateId = ids[predicate])) return quads;
+  //   if (isString(object)    && !(objectId    = ids[object]))    return quads;
+
+  //   for (var graphId in graphs) {
+  //     // Only if the specified graph contains triples, there can be results
+  //     if (graphContents = graphs[graphId]) {
+  //       // Choose the optimal index, based on what fields are present
+  //       if (subjectId) {
+  //         if (objectId)
+  //         // If subject and object are given, the object index will be the fastest
+  //           quads.push(this._findInIndex(graphContents.objects, objectId, subjectId, predicateId,
+  //                                        'object', 'subject', 'predicate', graphId));
+  //         else
+  //         // If only subject and possibly predicate are given, the subject index will be the fastest
+  //           quads.push(this._findInIndex(graphContents.subjects, subjectId, predicateId, null,
+  //                                        'subject', 'predicate', 'object', graphId));
+  //       }
+  //       else if (predicateId)
+  //       // If only predicate and possibly object are given, the predicate index will be the fastest
+  //         quads.push(this._findInIndex(graphContents.predicates, predicateId, objectId, null,
+  //                                      'predicate', 'object', 'subject', graphId));
+  //       else if (objectId)
+  //       // If only object is given, the object index will be the fastest
+  //         quads.push(this._findInIndex(graphContents.objects, objectId, null, null,
+  //                                      'object', 'subject', 'predicate', graphId));
+  //       else
+  //       // If nothing is given, iterate subjects and predicates first
+  //         quads.push(this._findInIndex(graphContents.subjects, null, null, null,
+  //                                      'subject', 'predicate', 'object', graphId));
+  //     }
+  //   }
+  //   return quads.length === 1 ? quads[0] : quads.concat.apply([], quads);
+  // },
+
   findByIRI: function (subject, predicate, object, graph) {
-    var quads = [], graphs = {}, graphContents,
-        ids = this._ids, subjectId, predicateId, objectId;
-    // Either loop over all graphs, or over just one selected graph
-    if (!isString(graph))
-      graphs = this._graphs;
-    else
-      graphs[graph] = this._graphs[graph];
-
-    // Translate IRIs to internal index keys.
-    // Optimization: if the entity doesn't exist, no triples with it exist.
-    if (isString(subject)   && !(subjectId   = ids[subject]))   return quads;
-    if (isString(predicate) && !(predicateId = ids[predicate])) return quads;
-    if (isString(object)    && !(objectId    = ids[object]))    return quads;
-
-    for (var graphId in graphs) {
-      // Only if the specified graph contains triples, there can be results
-      if (graphContents = graphs[graphId]) {
-        // Choose the optimal index, based on what fields are present
-        if (subjectId) {
-          if (objectId)
-          // If subject and object are given, the object index will be the fastest
-            quads.push(this._findInIndex(graphContents.objects, objectId, subjectId, predicateId,
-                                         'object', 'subject', 'predicate', graphId));
-          else
-          // If only subject and possibly predicate are given, the subject index will be the fastest
-            quads.push(this._findInIndex(graphContents.subjects, subjectId, predicateId, null,
-                                         'subject', 'predicate', 'object', graphId));
-        }
-        else if (predicateId)
-        // If only predicate and possibly object are given, the predicate index will be the fastest
-          quads.push(this._findInIndex(graphContents.predicates, predicateId, objectId, null,
-                                       'predicate', 'object', 'subject', graphId));
-        else if (objectId)
-        // If only object is given, the object index will be the fastest
-          quads.push(this._findInIndex(graphContents.objects, objectId, null, null,
-                                       'object', 'subject', 'predicate', graphId));
-        else
-        // If nothing is given, iterate subjects and predicates first
-          quads.push(this._findInIndex(graphContents.subjects, null, null, null,
-                                       'subject', 'predicate', 'object', graphId));
-      }
-    }
-    return quads.length === 1 ? quads[0] : quads.concat.apply([], quads);
+    var out = [];
+    this.someByIRI(function (q) {
+      out.push(q);
+      return false;
+    }, subject, predicate, object, graph);
+    return out;
   },
 
   // ### `count` returns the number of triples matching a pattern, expanding prefixes as necessary.

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -130,6 +130,79 @@ N3Store.prototype = {
     return results;
   },
 
+  _someInIndex: function (index0, key0, key1, key2, name0, name1, name2, graph, fn) {
+    var tmp, index1, index2, varCount = !key0 + !key1 + !key2,
+        // depending on the number of variables, keys or reverse index are faster
+        entityKeys = varCount > 1 ? Object.keys(this._ids) : this._entities;
+
+    // If a key is specified, use only that part of index 0.
+    if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
+    for (var value0 in index0) {
+      var entity0 = entityKeys[value0];
+
+      if (index1 = index0[value0]) {
+        // If a key is specified, use only that part of index 1.
+        if (key1) (tmp = index1, index1 = {})[key1] = tmp[key1];
+        for (var value1 in index1) {
+          var entity1 = entityKeys[value1];
+
+          if (index2 = index1[value1]) {
+            // If a key is specified, use only that part of index 2, if it exists.
+            var values = key2 ? (key2 in index2 ? [key2] : []) : Object.keys(index2);
+            // Create triples for all items found in index 2.
+            for (var l = values.length - 1; l >= 0; l--) {
+              var result = { subject: '', predicate: '', object: '', graph: graph };
+              result[name0] = entity0;
+              result[name1] = entity1;
+              result[name2] = entityKeys[values[l]];
+              if (fn(result.subject, result.predicate, result.object, result.graph)) {
+                return true;
+              }
+            }
+          }
+        }
+      }
+    }
+    return false;
+  },
+
+  _lookupIndex0lookupIndex1loopIndex2: function (index0, key0, key1, fn) {
+    var index1, index2, key2;
+    // Lookup.
+    if (!(index1 = index0[key0])) return;
+    // Lookup.
+    if (!(index2 = index1[key1])) return;
+    // Loop.
+    for (key2 in index2)
+      fn(key2);
+  },
+
+  _lookupIndex0loopIndex1: function (index0, key0, fn) {
+    var index1, key1;
+    // Lookup.
+    if (!(index1 = index0[key0])) return;
+    // Loop.
+    for (key1 in index1)
+      fn(key1);
+  },
+
+  _loopIndex0lookupIndex1: function (index0, key1, fn) {
+    var key0, index1;
+    // Loop.
+    for (key0 in index0) {
+      index1 = index0[key0];
+      // Lookup.
+      if (index1[key1])
+        fn(key0);
+    }
+  },
+
+  _loopIndex0: function (index0, fn) {
+    // Loop.
+    for (var key0 in index0)
+      fn(key0);
+  },
+
   // ### `_countInIndex` counts matching triples in a three-layered index.
   // The index base is `index0` and the keys at each level are `key0`, `key1`, and `key2`.
   // Any of these keys can be `null`, which is interpreted as a wildcard.
@@ -361,6 +434,382 @@ N3Store.prototype = {
       return this._countInIndex(graphItem.objects, object, subject, predicate);
     }
   },
+
+  forEach: function (fn, subject, predicate, object, graph) {
+    var prefixes = this._prefixes;
+    this.forEachByIRI(
+      fn,
+      expandPrefixedName(subject,   prefixes),
+      expandPrefixedName(predicate, prefixes),
+      expandPrefixedName(object,    prefixes),
+      expandPrefixedName(graph,     prefixes)
+    );
+  },
+
+  forEachByIRI: function (fn, subject, predicate, object, graph) {
+    this.someByIRI(function (s, p, o, g) {
+      fn(s, p, o, g);
+      return false;
+    }, subject, predicate, object, graph);
+  },
+
+  every: function (fn, subject, predicate, object, graph) {
+    var prefixes = this._prefixes;
+    return this.everyByIRI(
+      fn,
+      expandPrefixedName(subject,   prefixes),
+      expandPrefixedName(predicate, prefixes),
+      expandPrefixedName(object,    prefixes),
+      expandPrefixedName(graph,     prefixes)
+    );
+  },
+
+  everyByIRI: function (fn, subject, predicate, object, graph) {
+    return !this.someByIRI(function (s, p, o, g) {
+      return !fn(s, p, o, g);
+    }, subject, predicate, object, graph);
+  },
+
+  some: function (fn, subject, predicate, object, graph) {
+    var prefixes = this._prefixes;
+    return this.someByIRI(
+      fn,
+      expandPrefixedName(subject,   prefixes),
+      expandPrefixedName(predicate, prefixes),
+      expandPrefixedName(object,    prefixes),
+      expandPrefixedName(graph,     prefixes)
+    );
+  },
+
+
+  someByIRI: function (fn, subject, predicate, object, graph) {
+    var graphs = {}, graphContents,
+        ids = this._ids, subjectId, predicateId, objectId;
+    // Either loop over all graphs, or over just one selected graph.
+    if (!graph)
+      graphs = this._graphs;
+    else
+      graphs[graph] = this._graphs[graph];
+
+    // Translate IRIs to internal index keys.
+    // Optimization: if the entity doesn't exist, no triples with it exist.
+    if (subject   && !(subjectId   = ids[subject]))   return false;
+    if (predicate && !(predicateId = ids[predicate])) return false;
+    if (object    && !(objectId    = ids[object]))    return false;
+
+    for (var graphId in graphs) {
+      // Only if the specified graph contains triples, there can be results
+      if (graphContents = graphs[graphId]) {
+        // Do not emit the default graph explicitly
+        if (graphId === DEFAULT_GRAPH)
+          graphId = '';
+
+        // Choose the optimal index, based on what fields are present
+        if (subjectId) {
+          if (objectId) {
+          // If subject and object are given, the object index will be the fastest.
+            if (this._someInIndex(graphContents.objects, objectId, subjectId, predicateId,
+                                  'object', 'subject', 'predicate', graphId, fn))
+              return true;
+          }
+          else
+            // If only subject and possibly predicate are given, the subject index will be the fastest.
+            if (this._someInIndex(graphContents.subjects, subjectId, predicateId, null,
+                                  'subject', 'predicate', 'object', graphId, fn))
+              return true;
+        }
+        else if (predicateId) {
+          // If only predicate and possibly object are given, the predicate index will be the fastest.
+          if (this._someInIndex(graphContents.predicates, predicateId, objectId, null,
+                                'predicate', 'object', 'subject', graphId, fn)) {
+            return true;
+          }
+        }
+        else if (objectId) {
+          // If only object is given, the object index will be the fastest.
+          if (this._someInIndex(graphContents.objects, objectId, null, null,
+                                'object', 'subject', 'predicate', graphId, fn)) {
+            return true;
+          }
+        }
+        else
+        // If nothing is given, iterate subjects and predicates first
+        if (this._someInIndex(graphContents.subjects, null, null, null,
+                              'subject', 'predicate', 'object', graphId, fn)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+
+  findGraphs: function (subject, predicate, object) {
+    var prefixes = this._prefixes;
+    return this.findGraphsByIRI(
+      expandPrefixedName(subject,   prefixes),
+      expandPrefixedName(predicate, prefixes),
+      expandPrefixedName(object,    prefixes)
+    );
+  },
+
+  findGraphsByIRI: function (subject, predicate, object) {
+    var out = [];
+    this.forGraphsByIRI(function (g) {
+      out.push(g);
+    }, subject, predicate, object);
+    return out;
+  },
+
+  forGraphs: function (fn, subject, predicate, object) {
+    var prefixes = this._prefixes;
+    this.forGraphsByIRI(
+      fn,
+      expandPrefixedName(subject,   prefixes),
+      expandPrefixedName(predicate, prefixes),
+      expandPrefixedName(object,    prefixes)
+    );
+  },
+
+  forGraphsByIRI: function (fn, subject, predicate, object) {
+    for (var graph in this._graphs) {
+      this.someByIRI(function (s, p, o, g) {
+        fn(g);
+        return true; // Halt iteration of some().
+      }, subject, predicate, object, graph);
+    }
+  },
+
+  findSubjects: function (predicate, object, graph) {
+    var prefixes = this._prefixes;
+    return this.findSubjectsByIRI(
+      expandPrefixedName(predicate, prefixes),
+      expandPrefixedName(object,    prefixes),
+      expandPrefixedName(graph,     prefixes)
+    );
+  },
+
+  findSubjectsByIRI: function (predicate, object, graph) {
+    var out = [];
+    this.forSubjectsByIRI(function (s) {
+      out.push(s);
+    }, predicate, object, graph);
+    return out;
+  },
+
+  forSubjects: function (fn, predicate, object, graph) {
+    var prefixes = this._prefixes;
+    this.forSubjectsByIRI(
+      fn,
+      expandPrefixedName(predicate, prefixes),
+      expandPrefixedName(object,    prefixes),
+      expandPrefixedName(graph,     prefixes)
+    );
+  },
+
+  forSubjectsByIRI: function (fn, predicate, object, graph) {
+    var seen = {}, ids = this._ids, graphs = {}, graphContents,
+        entityKeys = this._entities;
+
+    // Either loop over all graphs, or over just one selected graph.
+    if (!graph)
+      graphs = this._graphs;
+    else
+      graphs[graph] = this._graphs[graph];
+
+    // Translate IRIs to internal index keys.
+    // Optimization: if the entity doesn't exist, no triples with it exist.
+    if (predicate && !(predicate = ids[predicate])) return;
+    if (object    && !(object    = ids[object]))    return;
+
+    function handleResultsFn(id) {
+      if (!(id in seen)) {
+        seen[id] = null;
+        fn(entityKeys[id]);
+      }
+    }
+
+    for (graph in graphs) {
+      // Only if the specified graph contains triples, there can be results
+      if (graphContents = graphs[graph]) {
+        // We want to list all subjects.
+        // The three index choices are: SPO POS OSP.
+
+        // Choose optimal index based on which fields are wildcards.
+        if (predicate) {
+          if (object)
+            // If predicate and object are given, the POS index is best.
+            // Lookup p, lookup o, loop s.
+            this._lookupIndex0lookupIndex1loopIndex2(graphContents.predicates, predicate, object, handleResultsFn);
+          else
+            // If only predicate is given, the SPO index is best.
+            // Loop s, lookup p.
+            this._loopIndex0lookupIndex1(graphContents.subjects, predicate, handleResultsFn);
+        }
+        else if (object)
+          // If only object is given, the OSP index is best.
+          // Lookup o, loop s.
+          this._lookupIndex0loopIndex1(graphContents.objects, object, handleResultsFn);
+        else
+          // If no params given, iterate all the subjects.
+          this._loopIndex0(graphContents.subjects, handleResultsFn);
+      }
+    }
+  },
+
+  findPredicates: function (subject, object, graph) {
+    var prefixes = this._prefixes;
+    return this.findPredicatesByIRI(
+      expandPrefixedName(subject, prefixes),
+      expandPrefixedName(object,  prefixes),
+      expandPrefixedName(graph,   prefixes)
+    );
+  },
+
+  findPredicatesByIRI: function (subject, object, graph) {
+    var out = [];
+    this.forPredicatesByIRI(function (p) {
+      out.push(p);
+    }, subject, object, graph);
+    return out;
+  },
+
+  forPredicates: function (fn, subject, object, graph) {
+    var prefixes = this._prefixes;
+    this.forPredicatesByIRI(
+      fn,
+      expandPrefixedName(subject, prefixes),
+      expandPrefixedName(object,  prefixes),
+      expandPrefixedName(graph,   prefixes)
+    );
+  },
+
+  forPredicatesByIRI: function (fn, subject, object, graph) {
+    var seen = {}, ids = this._ids, graphs = this._graphs, graphContents,
+        entityKeys = this._entities;
+
+    // Either loop over all graphs, or over just one selected graph.
+    if (!graph)
+      graphs = this._graphs;
+    else
+      graphs[graph] = this._graphs[graph];
+
+    // Translate IRIs to internal index keys.
+    // Optimization: if the entity doesn't exist, no triples with it exist.
+    if (subject && !(subject = ids[subject])) return;
+    if (object  && !(object  = ids[object]))  return;
+
+    function handleResultsFn(id) {
+      if (!(id in seen)) {
+        seen[id] = null;
+        fn(entityKeys[id]);
+      }
+    }
+
+    for (graph in graphs) {
+      // Only if the specified graph contains triples, there can be results
+      if (graphContents = graphs[graph]) {
+        // We want to list all predicates.
+        // The three index choices are: SPO POS OSP.
+
+        // Choose optimal index based on which fields are wildcards.
+        if (subject) {
+          if (object)
+            // If subject and object are given, the OSP index is best.
+            // Lookup o, lookup s, loop p.
+            this._lookupIndex0lookupIndex1loopIndex2(graphContents.objects, subject, object, handleResultsFn);
+          else
+            // If only subject is given, the SPO index is best.
+            // lookup s, loop p.
+            this._lookupIndex0loopIndex1(graphContents.subjects, subject, handleResultsFn);
+        }
+        else if (object)
+          // If only object is given, the POS index is best.
+          // Loop p, lookup o.
+          this._loopIndex0lookupIndex1(graphContents.predicates, object, handleResultsFn);
+        else
+          // If no params given, iterate all the predicates.
+          this._loopIndex0(graphContents.predicates, handleResultsFn);
+      }
+    }
+  },
+
+  findObjects: function (subject, predicate, graph) {
+    var prefixes = this._prefixes;
+    return this.findObjectsByIRI(
+      expandPrefixedName(subject,   prefixes),
+      expandPrefixedName(predicate, prefixes),
+      expandPrefixedName(graph,     prefixes)
+    );
+  },
+
+  findObjectsByIRI: function (subject, predicate, graph) {
+    var out = [];
+    this.forObjectsByIRI(function (o) {
+      out.push(o);
+    }, subject, predicate, graph);
+    return out;
+  },
+
+  forObject: function (fn, subject, predicate, graph) {
+    var prefixes = this._prefixes;
+    this.forObjectsByIRI(
+      fn,
+      expandPrefixedName(subject,   prefixes),
+      expandPrefixedName(predicate, prefixes),
+      expandPrefixedName(graph,     prefixes)
+    );
+  },
+
+  forObjectsByIRI: function (fn, subject, predicate, graph) {
+    var seen = {}, ids = this._ids, graphs = this._graphs, graphContents,
+        entityKeys = this._entities;
+
+    // Either loop over all graphs, or over just one selected graph.
+    if (!graph)
+      graphs = this._graphs;
+    else
+      graphs[graph] = this._graphs[graph];
+
+    // Translate IRIs to internal index keys.
+    // Optimization: if the entity doesn't exist, no triples with it exist.
+    if (subject   && !(subject   = ids[subject]))   return;
+    if (predicate && !(predicate = ids[predicate])) return;
+
+    function handleResultsFn(id) {
+      if (!(id in seen)) {
+        seen[id] = null;
+        fn(entityKeys[id]);
+      }
+    }
+
+    for (graph in graphs) {
+      // Only if the specified graph contains triples, there can be results
+      if (graphContents = graphs[graph]) {
+        // We want to list all predicates.
+        // The three index choices are: SPO POS OSP.
+
+        // Choose optimal index based on which fields are wildcards.
+        if (subject) {
+          if (predicate)
+            // If subject and predicate are given, the SPO index is best.
+            // Lookup s, lookup p, loop o.
+            this._lookupIndex0lookupIndex1loopIndex2(graphContents.subjects, subject, predicate, handleResultsFn);
+          else
+            // If only subject is given, the OSP index is best.
+            // loop o, lookup s.
+            this._loopIndex0lookupIndex1(graphContents.objects, subject, handleResultsFn);
+        }
+        else if (predicate)
+          // If only predicate is given, the POS index is best.
+          // Looukp p, loop o.
+          this._lookupIndex0loopIndex1(graphContents.predicates, predicate, handleResultsFn);
+        else
+          // If no params given, iterate all the objects.
+          this._loopIndex0(graphContents.objects, handleResultsFn);
+      }
+    }
+  },
+
 
   // ### `createBlankNode` creates a new blank node, returning its name.
   createBlankNode: function (suggestedName) {

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -272,6 +272,8 @@ N3Store.prototype = {
 
     // console.log('given key0, varCount ', varCount);
 
+    // TODO(js) This is the method that /appears/ to be performing more slowly then before.
+
     // Lookup
     if (key0 in index0) {
       var index1 = index0[key0];

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -164,39 +164,31 @@ N3Store.prototype = {
     return false;
   },
 
-  _lookupIndex0lookupIndex1loopIndex2: function (index0, key0, key1, fn) {
+  _index2KeysGivenKey0And1: function (index0, key0, key1, fn) {
     var index1, index2, key2;
-    // Lookup.
     if (!(index1 = index0[key0])) return;
-    // Lookup.
     if (!(index2 = index1[key1])) return;
-    // Loop.
     for (key2 in index2)
       fn(key2);
   },
 
-  _lookupIndex0loopIndex1: function (index0, key0, fn) {
+  _index1KeysGivenKey0: function (index0, key0, fn) {
     var index1, key1;
-    // Lookup.
     if (!(index1 = index0[key0])) return;
-    // Loop.
     for (key1 in index1)
       fn(key1);
   },
 
-  _loopIndex0lookupIndex1: function (index0, key1, fn) {
+  _index0KeysGivenKey1: function (index0, key1, fn) {
     var key0, index1;
-    // Loop.
     for (key0 in index0) {
       index1 = index0[key0];
-      // Lookup.
       if (index1[key1])
         fn(key0);
     }
   },
 
-  _loopIndex0: function (index0, fn) {
-    // Loop.
+  _index0Keys: function (index0, fn) {
     for (var key0 in index0)
       fn(key0);
   },
@@ -637,19 +629,19 @@ N3Store.prototype = {
           if (object)
             // If predicate and object are given, the POS index is best.
             // Lookup p, lookup o, loop s.
-            this._lookupIndex0lookupIndex1loopIndex2(graphContents.predicates, predicate, object, handleResultsFn);
+            this._index2KeysGivenKey0And1(graphContents.predicates, predicate, object, handleResultsFn);
           else
             // If only predicate is given, the SPO index is best.
             // Loop s, lookup p.
-            this._loopIndex0lookupIndex1(graphContents.subjects, predicate, handleResultsFn);
+            this._index0KeysGivenKey1(graphContents.subjects, predicate, handleResultsFn);
         }
         else if (object)
           // If only object is given, the OSP index is best.
           // Lookup o, loop s.
-          this._lookupIndex0loopIndex1(graphContents.objects, object, handleResultsFn);
+          this._index1KeysGivenKey0(graphContents.objects, object, handleResultsFn);
         else
           // If no params given, iterate all the subjects.
-          this._loopIndex0(graphContents.subjects, handleResultsFn);
+          this._index0Keys(graphContents.subjects, handleResultsFn);
       }
     }
   },
@@ -714,19 +706,19 @@ N3Store.prototype = {
           if (object)
             // If subject and object are given, the OSP index is best.
             // Lookup o, lookup s, loop p.
-            this._lookupIndex0lookupIndex1loopIndex2(graphContents.objects, subject, object, handleResultsFn);
+            this._index2KeysGivenKey0And1(graphContents.objects, subject, object, handleResultsFn);
           else
             // If only subject is given, the SPO index is best.
             // lookup s, loop p.
-            this._lookupIndex0loopIndex1(graphContents.subjects, subject, handleResultsFn);
+            this._index1KeysGivenKey0(graphContents.subjects, subject, handleResultsFn);
         }
         else if (object)
           // If only object is given, the POS index is best.
           // Loop p, lookup o.
-          this._loopIndex0lookupIndex1(graphContents.predicates, object, handleResultsFn);
+          this._index0KeysGivenKey1(graphContents.predicates, object, handleResultsFn);
         else
           // If no params given, iterate all the predicates.
-          this._loopIndex0(graphContents.predicates, handleResultsFn);
+          this._index0Keys(graphContents.predicates, handleResultsFn);
       }
     }
   },
@@ -791,19 +783,19 @@ N3Store.prototype = {
           if (predicate)
             // If subject and predicate are given, the SPO index is best.
             // Lookup s, lookup p, loop o.
-            this._lookupIndex0lookupIndex1loopIndex2(graphContents.subjects, subject, predicate, handleResultsFn);
+            this._index2KeysGivenKey0And1(graphContents.subjects, subject, predicate, handleResultsFn);
           else
             // If only subject is given, the OSP index is best.
             // loop o, lookup s.
-            this._loopIndex0lookupIndex1(graphContents.objects, subject, handleResultsFn);
+            this._index0KeysGivenKey1(graphContents.objects, subject, handleResultsFn);
         }
         else if (predicate)
           // If only predicate is given, the POS index is best.
           // Looukp p, loop o.
-          this._lookupIndex0loopIndex1(graphContents.predicates, predicate, handleResultsFn);
+          this._index1KeysGivenKey0(graphContents.predicates, predicate, handleResultsFn);
         else
           // If no params given, iterate all the objects.
-          this._loopIndex0(graphContents.objects, handleResultsFn);
+          this._index0Keys(graphContents.objects, handleResultsFn);
       }
     }
   },

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -81,82 +81,82 @@ N3Store.prototype = {
     delete index0[key0];
   },
 
-  // ### `_findInIndex` finds a set of triples in a three-layered index.
-  // The index base is `index0` and the keys at each level are `key0`, `key1`, and `key2`.
-  // Any of these keys can be undefined, which is interpreted as a wildcard.
-  // `name0`, `name1`, and `name2` are the names of the keys at each level,
-  // used when reconstructing the resulting triple
-  // (for instance: _subject_, _predicate_, and _object_).
-  // Finally, `graph` will be the graph of the created triples.
-  _findInIndex: function (index0, key0, key1, key2, name0, name1, name2, graph) {
-    var results = [], tmp, index1, index2, varCount = !key0 + !key1 + !key2,
-        // depending on the number of variables, keys or reverse index are faster
-        entityKeys = varCount > 1 ? Object.keys(this._ids) : this._entities;
+  // // ### `_findInIndex` finds a set of triples in a three-layered index.
+  // // The index base is `index0` and the keys at each level are `key0`, `key1`, and `key2`.
+  // // Any of these keys can be undefined, which is interpreted as a wildcard.
+  // // `name0`, `name1`, and `name2` are the names of the keys at each level,
+  // // used when reconstructing the resulting triple
+  // // (for instance: _subject_, _predicate_, and _object_).
+  // // Finally, `graph` will be the graph of the created triples.
+  // _findInIndex: function (index0, key0, key1, key2, name0, name1, name2, graph) {
+  //   var results = [], tmp, index1, index2, varCount = !key0 + !key1 + !key2,
+  //       // depending on the number of variables, keys or reverse index are faster
+  //       entityKeys = varCount > 1 ? Object.keys(this._ids) : this._entities;
 
-    // If a key is specified, use only that part of index 0
-    if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
-    for (var value0 in index0) {
-      var entity0 = entityKeys[value0];
+  //   // If a key is specified, use only that part of index 0
+  //   if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
+  //   for (var value0 in index0) {
+  //     var entity0 = entityKeys[value0];
 
-      if (index1 = index0[value0]) {
-        // If a key is specified, use only that part of index 1
-        if (key1) (tmp = index1, index1 = {})[key1] = tmp[key1];
-        for (var value1 in index1) {
-          var entity1 = entityKeys[value1];
+  //     if (index1 = index0[value0]) {
+  //       // If a key is specified, use only that part of index 1
+  //       if (key1) (tmp = index1, index1 = {})[key1] = tmp[key1];
+  //       for (var value1 in index1) {
+  //         var entity1 = entityKeys[value1];
 
-          if (index2 = index1[value1]) {
-            // If a key is specified, use only that part of index 2, if it exists
-            var values = key2 ? (key2 in index2 ? [key2] : []) : Object.keys(index2);
-            // Create triples for all items found in index 2
-            for (var l = values.length - 1; l >= 0; l--) {
-              var result = { subject: '', predicate: '', object: '', graph: graph };
-              result[name0] = entity0;
-              result[name1] = entity1;
-              result[name2] = entityKeys[values[l]];
-              results.push(result);
-            }
-          }
-        }
-      }
-    }
-    return results;
-  },
+  //         if (index2 = index1[value1]) {
+  //           // If a key is specified, use only that part of index 2, if it exists
+  //           var values = key2 ? (key2 in index2 ? [key2] : []) : Object.keys(index2);
+  //           // Create triples for all items found in index 2
+  //           for (var l = values.length - 1; l >= 0; l--) {
+  //             var result = { subject: '', predicate: '', object: '', graph: graph };
+  //             result[name0] = entity0;
+  //             result[name1] = entity1;
+  //             result[name2] = entityKeys[values[l]];
+  //             results.push(result);
+  //           }
+  //         }
+  //       }
+  //     }
+  //   }
+  //   return results;
+  // },
 
-  _someInIndex: function (index0, key0, key1, key2, name0, name1, name2, graph, fn) {
-    var tmp, index1, index2, varCount = !key0 + !key1 + !key2,
-        // depending on the number of variables, keys or reverse index are faster
-        entityKeys = varCount > 1 ? Object.keys(this._ids) : this._entities;
+  // _someInIndex: function (index0, key0, key1, key2, name0, name1, name2, graph, fn) {
+  //   var tmp, index1, index2, varCount = !key0 + !key1 + !key2,
+  //       // depending on the number of variables, keys or reverse index are faster
+  //       entityKeys = varCount > 1 ? Object.keys(this._ids) : this._entities;
 
-    // If a key is specified, use only that part of index 0.
-    if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
-    for (var value0 in index0) {
-      var entity0 = entityKeys[value0];
+  //   // If a key is specified, use only that part of index 0.
+  //   if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
+  //   for (var value0 in index0) {
+  //     var entity0 = entityKeys[value0];
 
-      if (index1 = index0[value0]) {
-        // If a key is specified, use only that part of index 1.
-        if (key1) (tmp = index1, index1 = {})[key1] = tmp[key1];
-        for (var value1 in index1) {
-          var entity1 = entityKeys[value1];
+  //     if (index1 = index0[value0]) {
+  //       // If a key is specified, use only that part of index 1.
+  //       if (key1) (tmp = index1, index1 = {})[key1] = tmp[key1];
+  //       for (var value1 in index1) {
+  //         var entity1 = entityKeys[value1];
 
-          if (index2 = index1[value1]) {
-            // If a key is specified, use only that part of index 2, if it exists.
-            var values = key2 ? (key2 in index2 ? [key2] : []) : Object.keys(index2);
-            // Create triples for all items found in index 2.
-            for (var l = values.length - 1; l >= 0; l--) {
-              var result = { subject: '', predicate: '', object: '', graph: graph };
-              result[name0] = entity0;
-              result[name1] = entity1;
-              result[name2] = entityKeys[values[l]];
-              if (fn(result)) {
-                return true;
-              }
-            }
-          }
-        }
-      }
-    }
-    return false;
-  },
+  //         if (index2 = index1[value1]) {
+  //           // If a key is specified, use only that part of index 2, if it exists.
+  //           var values = key2 ? (key2 in index2 ? [key2] : []) : Object.keys(index2);
+  //           // Create triples for all items found in index 2.
+  //           for (var l = values.length - 1; l >= 0; l--) {
+  //             var result = { subject: '', predicate: '', object: '', graph: graph };
+  //             result[name0] = entity0;
+  //             result[name1] = entity1;
+  //             result[name2] = entityKeys[values[l]];
+  //             if (fn(result)) {
+  //               return true;
+  //             }
+  //           }
+  //         }
+  //       }
+  //     }
+  //   }
+  //   return false;
+  // },
 
   _index2KeysGivenKey0And1: function (index0, key0, key1, fn) {
     var index1, index2, key2;

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -266,13 +266,13 @@ N3Store.prototype = {
 
     // It turns out that varCount is actually a count of null parameters.
     // We always have a null parameter count of 2.
-    // var entityKeys = Object.keys(this._ids); // Fastest - according to above rule
+    var entityKeys = Object.keys(this._ids); // Fastest - according to above rule
 
-    var entityKeys = this._entities; // But I'm actually seeing this as a fraction faster?
+    // var entityKeys = this._entities; // But I'm actually not seeing much difference at all?
 
     // console.log('given key0, varCount ', varCount);
 
-    // TODO(js) This is the method that /appears/ to be performing more slowly then before.
+    // TODO(js) This is the method that /appears/ to be performing more slowly than before.
 
     // Lookup
     if (key0 in index0) {

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -266,7 +266,9 @@ N3Store.prototype = {
 
     // It turns out that varCount is actually a count of null parameters.
     // We always have a null parameter count of 2.
-    var entityKeys = Object.keys(this._ids);
+    // var entityKeys = Object.keys(this._ids); // Fastest - according to above rule
+
+    var entityKeys = this._entities; // But I'm actually seeing this as a fraction faster?
 
     // console.log('given key0, varCount ', varCount);
 

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -742,7 +742,7 @@ N3Store.prototype = {
     return out;
   },
 
-  forObject: function (fn, subject, predicate, graph) {
+  forObjects: function (fn, subject, predicate, graph) {
     var prefixes = this._prefixes;
     this.forObjectsByIRI(
       fn,

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -47,6 +47,7 @@ N3Store.prototype = {
       return size;
 
     // Calculate the number of triples by counting to the deepest level.
+    size = 0;
     var graphs = this._graphs, subjects, subject;
     for (var graphKey in graphs)
       for (var subjectKey in (subjects = graphs[graphKey].subjects))
@@ -457,9 +458,15 @@ N3Store.prototype = {
   },
 
   everyByIRI: function (fn, subject, predicate, object, graph) {
-    return !this.someByIRI(function (quad) {
+    var some = false;
+    var every = !this.someByIRI(function (quad) {
+      some = true;
       return !fn(quad);
     }, subject, predicate, object, graph);
+    if (!some) {
+      return false;
+    }
+    return every;
   },
 
   some: function (fn, subject, predicate, object, graph) {
@@ -708,7 +715,7 @@ N3Store.prototype = {
           if (object)
             // If subject and object are given, the OSP index is best.
             // Lookup o, lookup s, loop p.
-            this._index2KeysGivenKey0And1(graphContents.objects, subject, object, handleResultsFn);
+            this._index2KeysGivenKey0And1(graphContents.objects, object, subject, handleResultsFn);
           else
             // If only subject is given, the SPO index is best.
             // lookup s, loop p.

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -133,27 +133,29 @@ N3Store.prototype = {
   _someInIndex: function (index0, key0, key1, key2, name0, name1, name2, graph, fn) {
     var tmp, index1, index2, varCount = !key0 + !key1 + !key2,
         // depending on the number of variables, keys or reverse index are faster
-        entityKeys = varCount > 1 ? Object.keys(this._ids) : this._entities,
-        result = { subject: '', predicate: '', object: '', graph: graph };
+        entityKeys = varCount > 1 ? Object.keys(this._ids) : this._entities;
 
     // If a key is specified, use only that part of index 0.
     if (key0) (tmp = index0, index0 = {})[key0] = tmp[key0];
     for (var value0 in index0) {
-      result[name0] = entityKeys[value0];
+      var entity0 = entityKeys[value0];
 
       if (index1 = index0[value0]) {
         // If a key is specified, use only that part of index 1.
         if (key1) (tmp = index1, index1 = {})[key1] = tmp[key1];
         for (var value1 in index1) {
-          result[name1] = entityKeys[value1];
+          var entity1 = entityKeys[value1];
 
           if (index2 = index1[value1]) {
             // If a key is specified, use only that part of index 2, if it exists.
             var values = key2 ? (key2 in index2 ? [key2] : []) : Object.keys(index2);
             // Create triples for all items found in index 2.
             for (var l = values.length - 1; l >= 0; l--) {
+              var result = { subject: '', predicate: '', object: '', graph: graph };
+              result[name0] = entity0;
+              result[name1] = entity1;
               result[name2] = entityKeys[values[l]];
-              if (fn(result.subject, result.predicate, result.object, result.graph)) {
+              if (fn(result)) {
                 return true;
               }
             }
@@ -437,8 +439,8 @@ N3Store.prototype = {
   },
 
   forEachByIRI: function (fn, subject, predicate, object, graph) {
-    this.someByIRI(function (s, p, o, g) {
-      fn(s, p, o, g);
+    this.someByIRI(function (quad) {
+      fn(quad);
       return false;
     }, subject, predicate, object, graph);
   },
@@ -455,8 +457,8 @@ N3Store.prototype = {
   },
 
   everyByIRI: function (fn, subject, predicate, object, graph) {
-    return !this.someByIRI(function (s, p, o, g) {
-      return !fn(s, p, o, g);
+    return !this.someByIRI(function (quad) {
+      return !fn(quad);
     }, subject, predicate, object, graph);
   },
 
@@ -562,8 +564,8 @@ N3Store.prototype = {
 
   forGraphsByIRI: function (fn, subject, predicate, object) {
     for (var graph in this._graphs) {
-      this.someByIRI(function (s, p, o, g) {
-        fn(g);
+      this.someByIRI(function (quad) {
+        fn(quad.graph);
         return true; // Halt iteration of some().
       }, subject, predicate, object, graph);
     }

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -27,10 +27,10 @@ describe('N3Store', function () {
     });
 
     describe('every()', function () {
-      function trueFn (q) {
+      function trueFn(q) {
         return true;
       }
-      function falseFn (q) {
+      function falseFn(q) {
         return false;
       }
       describe('with no parameters and a callback always returning true', function () {
@@ -46,10 +46,10 @@ describe('N3Store', function () {
     });
 
     describe('some()', function () {
-      function trueFn (q) {
+      function trueFn(q) {
         return true;
       }
-      function falseFn (q) {
+      function falseFn(q) {
         return false;
       }
       describe('with no parameters and a callback always returning true', function () {
@@ -277,7 +277,6 @@ describe('N3Store', function () {
     });
 
     describe('findGraphs()', function () {
-
       describe('with existing subject, predicate and object parameters', function () {
         it('should return all graphs with this subject, predicate and object', function () {
           store.findGraphs('s1', 'p1', 'o1').should.have.members(['c4', '']);
@@ -328,7 +327,6 @@ describe('N3Store', function () {
     });
 
     describe('findSubjects()', function () {
-
       describe('with existing predicate, object and graph parameters', function () {
         it('should return all subjects with this predicate, object and graph', function () {
           store.findSubjects('p1', 'o1', 'c4').should.have.members(['s1']);
@@ -379,7 +377,6 @@ describe('N3Store', function () {
     });
 
     describe('findPredicates()', function () {
-
       describe('with existing subject, object and graph parameters', function () {
         it('should return all predicates with this subject, object and graph', function () {
           store.findPredicates('s1', 'o1', 'c4').should.have.members(['p1']);
@@ -430,7 +427,6 @@ describe('N3Store', function () {
     });
 
     describe('findObjects()', function () {
-
       describe('with existing subject, predicate and graph parameters', function () {
         it('should return all objects with this subject, predicate and graph', function () {
           store.findObjects('s1', 'p1', '').should.have.members(['o1', 'o2']);
@@ -481,9 +477,8 @@ describe('N3Store', function () {
     });
 
     describe('forEach()', function () {
-
       var quads = [];
-      function resultCollectorFn (q) {
+      function resultCollectorFn(q) {
         quads.push(q);
       }
 
@@ -625,7 +620,7 @@ describe('N3Store', function () {
 
     describe('forGraphs()', function () {
       var graphs = [];
-      function resultCollectorFn (g) {
+      function resultCollectorFn(g) {
         graphs.push(g);
       }
       describe('with existing subject, predicate and object parameters', function () {
@@ -639,7 +634,7 @@ describe('N3Store', function () {
 
     describe('forSubjects()', function () {
       var subjects = [];
-      function resultCollectorFn (s) {
+      function resultCollectorFn(s) {
         subjects.push(s);
       }
       describe('with existing predicate, object and graph parameters', function () {
@@ -653,7 +648,7 @@ describe('N3Store', function () {
 
     describe('forPredicates()', function () {
       var predicates = [];
-      function resultCollectorFn (p) {
+      function resultCollectorFn(p) {
         predicates.push(p);
       }
       describe('with existing subject, object and graph parameters', function () {
@@ -667,7 +662,7 @@ describe('N3Store', function () {
 
     describe('forObjects()', function () {
       var objects = [];
-      function resultCollectorFn (o) {
+      function resultCollectorFn(o) {
         objects.push(o);
       }
       describe('with existing subject, predicate and graph parameters', function () {
@@ -680,14 +675,14 @@ describe('N3Store', function () {
     });
 
     describe('every()', function () {
-      function trueFn (q) {
+      function trueFn(q) {
         return true;
       }
-      function falseFn (q) {
+      function falseFn(q) {
         return false;
       }
       var count = 3;
-      function falseThirdTimeFn (q) {
+      function falseThirdTimeFn(q) {
         if (count > 0) {
           count--;
           return true;
@@ -712,14 +707,14 @@ describe('N3Store', function () {
     });
 
     describe('some()', function () {
-      function trueFn (q) {
+      function trueFn(q) {
         return true;
       }
-      function falseFn (q) {
+      function falseFn(q) {
         return false;
       }
       var count = 3;
-      function trueThirdTimeFn (q) {
+      function trueThirdTimeFn(q) {
         if (count > 0) {
           count--;
           return false;

--- a/test/N3Store-test.js
+++ b/test/N3Store-test.js
@@ -26,12 +26,58 @@ describe('N3Store', function () {
       store.find().should.be.empty;
     });
 
+    describe('every()', function () {
+      function trueFn (q) {
+        return true;
+      }
+      function falseFn (q) {
+        return false;
+      }
+      describe('with no parameters and a callback always returning true', function () {
+        it('should return false', function () {
+          store.every(trueFn, null, null, null, null).should.be.false;
+        });
+      });
+      describe('with no parameters and a callback always returning false', function () {
+        it('should return false', function () {
+          store.every(falseFn, null, null, null, null).should.be.false;
+        });
+      });
+    });
+
+    describe('some()', function () {
+      function trueFn (q) {
+        return true;
+      }
+      function falseFn (q) {
+        return false;
+      }
+      describe('with no parameters and a callback always returning true', function () {
+        it('should return false', function () {
+          store.some(trueFn, null, null, null, null).should.be.false;
+        });
+      });
+      describe('with no parameters and a callback always returning false', function () {
+        it('should return false', function () {
+          store.some(falseFn, null, null, null, null).should.be.false;
+        });
+      });
+    });
+
+    it('should still have size 0 (instead of null) after adding and removing a triple', function () {
+      expect(store.size).to.eql(0);
+      store.addTriple('a', 'b', 'c').should.be.true;
+      store.removeTriple('a', 'b', 'c').should.be.true;
+      expect(store.size).to.eql(0);
+    });
+
     it('should be able to generate unnamed blank nodes', function () {
       store.createBlankNode().should.eql('_:b0');
       store.createBlankNode().should.eql('_:b1');
 
       store.addTriple('_:b0', '_:b1', '_:b2').should.be.true;
       store.createBlankNode().should.eql('_:b3');
+      store.removeTriples(store.find());
     });
 
     it('should be able to generate named blank nodes', function () {
@@ -43,6 +89,7 @@ describe('N3Store', function () {
     it('should be able to store triples with generated blank nodes', function () {
       store.addTriple(store.createBlankNode('x'), 'b', 'c').should.be.true;
       shouldIncludeAll(store.find(null, 'b'), ['_:x1', 'b', 'd']);
+      store.removeTriples(store.find());
     });
 
     it('should have a fixed default graph', function () {
@@ -224,6 +271,459 @@ describe('N3Store', function () {
 
     describe('when searched with a non-existing non-default graph parameter', function () {
       itShouldBeEmpty(store.find(null, null, null, 'c5'));
+    });
+
+    describe('findGraphs()', function () {
+
+      describe('with existing subject, predicate and object parameters', function () {
+        it('should return all graphs with this subject, predicate and object', function () {
+          store.findGraphs('s1', 'p2', 'o3').should.have.members(['c4']);
+        });
+      });
+
+      describe('with existing subject and predicate parameters', function () {
+        it('should return all graphs with this subject and predicate', function () {
+          store.findGraphs('s1', 'p2', null).should.have.members(['c4', '']);
+        });
+      });
+
+      describe('with existing subject and object parameters', function () {
+        it('should return all graphs with this subject and object', function () {
+          store.findGraphs('s1', null, 'o2').should.have.members(['']);
+        });
+      });
+
+      describe('with existing predicate and object parameters', function () {
+        it('should return all graphs with this predicate and object', function () {
+          store.findGraphs(null, 'p2', 'o3').should.have.members(['c4']);
+        });
+      });
+
+      describe('with an existing subject parameter', function () {
+        it('should return all graphs with this subject', function () {
+          store.findGraphs('s1', null, null).should.have.members(['c4', '']);
+        });
+      });
+
+      describe('with an existing predicate parameter', function () {
+        it('should return all graphs with this predicate', function () {
+          store.findGraphs(null, 'p2', null).should.have.members(['c4', '']);
+        });
+      });
+
+      describe('with an existing object parameter', function () {
+        it('should return all graphs with this object', function () {
+          store.findGraphs(null, null, 'o3').should.have.members(['c4']);
+        });
+      });
+
+      describe('with no parameters', function () {
+        it('should return all graphs', function () {
+          store.findGraphs(null, null, null).should.have.members(['c4', '']);
+        });
+      });
+    });
+
+    describe('findSubjects()', function () {
+
+      describe('with existing predicate, object and graph parameters', function () {
+        it('should return all subjects with this predicate, object and graph', function () {
+          store.findSubjects('p2', 'o3', 'c4').should.have.members(['s1']);
+        });
+      });
+
+      describe('with existing predicate and object parameters', function () {
+        it('should return all subjects with this predicate and object', function () {
+          store.findSubjects('p2', 'o2', null).should.have.members(['s1']);
+        });
+      });
+
+      describe('with existing predicate and graph parameters', function () {
+        it('should return all subjects with this predicate and graph', function () {
+          store.findSubjects('p1', null, store.defaultGraph).should.have.members(['s1', 's2']);
+        });
+      });
+
+      describe('with existing object and graph parameters', function () {
+        it('should return all subjects with this object and graph', function () {
+          store.findSubjects(null, 'o1', store.defaultGraph).should.have.members(['s1', 's2']);
+        });
+      });
+
+      describe('with an existing predicate parameter', function () {
+        it('should return all subjects with this predicate', function () {
+          store.findSubjects('p1', null, null).should.have.members(['s1', 's2']);
+        });
+      });
+
+      describe('with an existing object parameter', function () {
+        it('should return all subjects with this object', function () {
+          store.findSubjects(null, 'o1', null).should.have.members(['s1', 's2']);
+        });
+      });
+
+      describe('with an existing graph parameter', function () {
+        it('should return all subjects in the graph', function () {
+          store.findSubjects(null, null, 'c4').should.have.members(['s1']);
+        });
+      });
+
+      describe('with no parameters', function () {
+        it('should return all subjects', function () {
+          store.findSubjects(null, null, null).should.have.members(['s1', 's2']);
+        });
+      });
+    });
+
+    describe('findPredicates()', function () {
+
+      describe('with existing subject, object and graph parameters', function () {
+        it('should return all predicates with this subject, object and graph', function () {
+          store.findPredicates('s1', 'o3', 'c4').should.have.members(['p2']);
+        });
+      });
+
+      describe('with existing subject and object parameters', function () {
+        it('should return all predicates with this subject and object', function () {
+          store.findPredicates('s1', 'o2', null).should.have.members(['p1', 'p2']);
+        });
+      });
+
+      describe('with existing subject and graph parameters', function () {
+        it('should return all predicates with this subject and graph', function () {
+          store.findPredicates('s1', null, store.defaultGraph).should.have.members(['p1', 'p2']);
+        });
+      });
+
+      describe('with existing object and graph parameters', function () {
+        it('should return all predicates with this object and graph', function () {
+          store.findPredicates(null, 'o1', store.defaultGraph).should.have.members(['p1']);
+        });
+      });
+
+      describe('with an existing subject parameter', function () {
+        it('should return all predicates with this subject', function () {
+          store.findPredicates('s2', null, null).should.have.members(['p1']);
+        });
+      });
+
+      describe('with an existing object parameter', function () {
+        it('should return all predicates with this object', function () {
+          store.findPredicates(null, 'o1', null).should.have.members(['p1']);
+        });
+      });
+
+      describe('with an existing graph parameter', function () {
+        it('should return all predicates in the graph', function () {
+          store.findPredicates(null, null, 'c4').should.have.members(['p2']);
+        });
+      });
+
+      describe('with no parameters', function () {
+        it('should return all predicates', function () {
+          store.findPredicates(null, null, null).should.have.members(['p1', 'p2']);
+        });
+      });
+    });
+
+    describe('findObjects()', function () {
+
+      describe('with existing subject, predicate and graph parameters', function () {
+        it('should return all objects with this subject, predicate and graph', function () {
+          store.findObjects('s1', 'p1', store.defaultGraph).should.have.members(['o1', 'o2']);
+        });
+      });
+
+      describe('with existing subject and predicate parameters', function () {
+        it('should return all objects with this subject and predicate', function () {
+          store.findObjects('s1', 'p2', null).should.have.members(['o2', 'o3']);
+        });
+      });
+
+      describe('with existing subject and graph parameters', function () {
+        it('should return all objects with this subject and graph', function () {
+          store.findObjects('s1', null, store.defaultGraph).should.have.members(['o1', 'o2']);
+        });
+      });
+
+      describe('with existing predicate and graph parameters', function () {
+        it('should return all objects with this predicate and graph', function () {
+          store.findObjects(null, 'p1', store.defaultGraph).should.have.members(['o1', 'o2']);
+        });
+      });
+
+      describe('with an existing subject parameter', function () {
+        it('should return all objects with this subject', function () {
+          store.findObjects('s1', null, null).should.have.members(['o1', 'o2', 'o3']);
+        });
+      });
+
+      describe('with an existing predicate parameter', function () {
+        it('should return all objects with this predicate', function () {
+          store.findObjects(null, 'p2', null).should.have.members(['o2', 'o3']);
+        });
+      });
+
+      describe('with an existing graph parameter', function () {
+        it('should return all objects in the graph', function () {
+          store.findObjects(null, null, 'c4').should.have.members(['o3']);
+        });
+      });
+
+      describe('with no parameters', function () {
+        it('should return all objects', function () {
+          store.findObjects(null, null, null).should.have.members(['o1', 'o2', 'o3']);
+        });
+      });
+    });
+
+    describe('forEach()', function () {
+
+      var quads = [];
+      function resultCollectorFn (q) {
+        quads.push(q);
+      }
+
+      describe('with existing subject, predicate, object and graph parameters', function () {
+        store.forEach(resultCollectorFn, 's1', 'p1', 'o2', store.defaultGraph);
+        it('should have iterated all items with this subject, predicate, object and graph',
+          shouldIncludeAll(quads, ['s1', 'p1', 'o2', '']));
+        quads = [];
+      });
+
+      describe('with existing subject, predicate and object parameters', function () {
+        store.forEach(resultCollectorFn, 's1', 'p2', 'o3', null);
+        it('should have iterated all items with this subject, predicate and object',
+          shouldIncludeAll(quads, ['s1', 'p2', 'o3', 'c4']));
+        quads = [];
+      });
+
+      describe('with existing subject, predicate and graph parameters', function () {
+        store.forEach(resultCollectorFn, 's1', 'p1', null, store.defaultGraph);
+        it('should have iterated all items with this subject, predicate and graph',
+          shouldIncludeAll(quads, ['s1', 'p1', 'o1', ''], ['s1', 'p1', 'o2', '']));
+        quads = [];
+      });
+
+      describe('with existing subject, object and graph parameters', function () {
+        store.forEach(resultCollectorFn, 's1', null, 'o2', store.defaultGraph);
+        it('should have iterated all items with this subject, object and graph',
+          shouldIncludeAll(quads, ['s1', 'p1', 'o2', ''], ['s1', 'p2', 'o2', '']));
+        quads = [];
+      });
+
+      describe('with existing predicate, object and graph parameters', function () {
+        store.forEach(resultCollectorFn, null, 'p1', 'o1', store.defaultGraph);
+        it('should have iterated all items with this predicate, object and graph',
+          shouldIncludeAll(quads, ['s1', 'p1', 'o1', ''], ['s2', 'p1', 'o1', '']));
+        quads = [];
+      });
+
+      describe('with existing subject and predicate parameters', function () {
+        store.forEach(resultCollectorFn, 's1', 'p2', null, null);
+        it('should iterate all items with this subject and predicate',
+          shouldIncludeAll(quads, ['s1', 'p2', 'o2', ''], ['s1', 'p2', 'o3', 'c4']));
+        quads = [];
+      });
+
+      describe('with existing subject and object parameters', function () {
+        store.forEach(resultCollectorFn, 's1', null, 'o2', null);
+        it('should iterate all items with this subject and predicate',
+          shouldIncludeAll(quads, ['s1', 'p1', 'o2', ''], ['s1', 'p2', 'o2', '']));
+        quads = [];
+      });
+
+      describe('with existing subject and graph parameters', function () {
+        store.forEach(resultCollectorFn, 's1', null, null, 'c4');
+        it('should iterate all items with this subject and graph',
+          shouldIncludeAll(quads, ['s1', 'p2', 'o3', 'c4']));
+        quads = [];
+      });
+
+      describe('with existing predicate and object parameters', function () {
+        store.forEach(resultCollectorFn, null, 'p1', 'o1', null);
+        it('should iterate all items with this predicate and object',
+          shouldIncludeAll(quads, ['s1', 'p1', 'o1', ''], ['s2', 'p1', 'o1', '']));
+        quads = [];
+      });
+
+      describe('with existing predicate and graph parameters', function () {
+        store.forEach(resultCollectorFn, null, 'p1', null, store.defaultGraph);
+        it('should iterate all items with this predicate and graph',
+          shouldIncludeAll(quads, ['s1', 'p1', 'o1', ''],
+                                    ['s1', 'p1', 'o2', ''],
+                                    ['s2', 'p1', 'o1', '']));
+        quads = [];
+      });
+
+      describe('with existing object and graph parameters', function () {
+        store.forEach(resultCollectorFn, null, null, 'o1', store.defaultGraph);
+        it('should iterate all items with this object and graph',
+          shouldIncludeAll(quads, ['s1', 'p1', 'o1', ''], ['s2', 'p1', 'o1', '']));
+        quads = [];
+      });
+
+      describe('with existing subject parameter', function () {
+        store.forEach(resultCollectorFn, 's2', null, null, null);
+        it('should iterate all items with this subject',
+          shouldIncludeAll(quads, ['s2', 'p1', 'o1', '']));
+        quads = [];
+      });
+
+      describe('with existing predicate parameter', function () {
+        store.forEach(resultCollectorFn, null, 'p2', null, null);
+        it('should iterate all items with this predicate',
+          shouldIncludeAll(quads, ['s1', 'p2', 'o2', ''], ['s1', 'p2', 'o3', 'c4']));
+        quads = [];
+      });
+
+      describe('with existing object parameter', function () {
+        store.forEach(resultCollectorFn, null, null, 'o1', null);
+        it('should iterate all items with this object',
+          shouldIncludeAll(quads, ['s1', 'p1', 'o1', ''], ['s2', 'p1', 'o1', '']));
+        quads = [];
+      });
+
+      describe('with existing graph parameter', function () {
+        store.forEach(resultCollectorFn, null, null, null, store.defaultGraph);
+        it('should iterate all items with this graph',
+          shouldIncludeAll(quads, ['s1', 'p1', 'o1'],
+                                    ['s1', 'p1', 'o2'],
+                                    ['s1', 'p2', 'o2'],
+                                    ['s2', 'p1', 'o1']));
+        quads = [];
+      });
+
+      describe('with no parameters', function () {
+        store.forEach(resultCollectorFn, null, null, null, null);
+        it('should iterate all items',
+          shouldIncludeAll(quads, ['s1', 'p1', 'o1'],
+                                    ['s1', 'p1', 'o2'],
+                                    ['s1', 'p2', 'o2'],
+                                    ['s2', 'p1', 'o1'],
+                                    ['s1', 'p2', 'o3', 'c4']));
+        quads = [];
+      });
+    });
+
+    describe('forGraphs()', function () {
+      var graphs = [];
+      function resultCollectorFn (g) {
+        graphs.push(g);
+      }
+      describe('with existing subject, predicate and object parameters', function () {
+        it('should iterate all graphs with this subject, predicate and object', function () {
+          store.forGraphs(resultCollectorFn, 's1', 'p1', 'o1');
+          graphs.should.have.members(['']);
+        });
+        graphs = [];
+      });
+    });
+
+    describe('forSubjects()', function () {
+      var subjects = [];
+      function resultCollectorFn (s) {
+        subjects.push(s);
+      }
+      describe('with existing predicate, object and graph parameters', function () {
+        it('should iterate all subjects with this predicate, object and graph', function () {
+          store.forSubjects(resultCollectorFn, 'p1', 'o1', store.defaultGraph);
+          subjects.should.have.members(['s1', 's2']);
+        });
+        subjects = [];
+      });
+    });
+
+    describe('forPredicates()', function () {
+      var predicates = [];
+      function resultCollectorFn (p) {
+        predicates.push(p);
+      }
+      describe('with existing subject, object and graph parameters', function () {
+        it('should iterate all predicates with this subject, object and graph', function () {
+          store.forPredicates(resultCollectorFn, 's1', 'o2', store.defaultGraph);
+          predicates.should.have.members(['p1', 'p2']);
+        });
+        predicates = [];
+      });
+    });
+
+    describe('forObjects()', function () {
+      var objects = [];
+      function resultCollectorFn (o) {
+        objects.push(o);
+      }
+      describe('with existing subject, predicate and graph parameters', function () {
+        it('should iterate all objects with this subject, predicate and graph', function () {
+          store.forObjects(resultCollectorFn, 's1', 'p1', store.defaultGraph);
+          objects.should.have.members(['o1', 'o2']);
+        });
+        objects = [];
+      });
+    });
+
+    describe('every()', function () {
+      function trueFn (q) {
+        return true;
+      }
+      function falseFn (q) {
+        return false;
+      }
+      var count = 3;
+      function falseThirdTimeFn (q) {
+        if (count > 0) {
+          count--;
+          return true;
+        }
+        return false;
+      }
+      describe('with no parameters and a callback always returning true', function () {
+        it('should return true', function () {
+          store.every(trueFn, null, null, null, null).should.be.true;
+        });
+      });
+      describe('with no parameters and a callback always returning false', function () {
+        it('should return false', function () {
+          store.every(falseFn, null, null, null, null).should.be.false;
+        });
+      });
+      describe('with no parameters and a callback that returns false after 3 calls', function () {
+        it('should return false', function () {
+          store.every(falseThirdTimeFn, null, null, null, null).should.be.false;
+        });
+      });
+    });
+
+    describe('some()', function () {
+      function trueFn (q) {
+        return true;
+      }
+      function falseFn (q) {
+        return false;
+      }
+      var count = 3;
+      function trueThirdTimeFn (q) {
+        if (count > 0) {
+          count--;
+          return false;
+        }
+        return true;
+      }
+      describe('with no parameters and a callback always returning true', function () {
+        it('should return true', function () {
+          store.some(trueFn, null, null, null, null).should.be.true;
+        });
+      });
+      describe('with no parameters and a callback always returning false', function () {
+        it('should return false', function () {
+          store.some(falseFn, null, null, null, null).should.be.false;
+        });
+      });
+      describe('with no parameters and a callback that returns true after 3 calls', function () {
+        it('should return false', function () {
+          store.some(trueThirdTimeFn, null, null, null, null).should.be.true;
+        });
+      });
     });
 
     describe('when counted without parameters', function () {


### PR DESCRIPTION
This is the result of an experiment. It's not really a pull request, although you're welcome to take the code if you wish :)

So... I wrote the 'four functions' version of `some`, and hooked up `find` to use `some`.

My benchmarks for current `master` are typically:

```
N3Store performance test
- Adding 16777216 triples to the default graph: 18528.181ms
* Memory usage for triples: 709MB
- Finding all 16777216 triples in the default graph 65536 times (0 variables): 88729.043ms
- Finding all 16777216 triples in the default graph 131072 times (1 variable): 5624.881ms
- Finding all 16777216 triples in the default graph 196608 times (2 variables): 5504.780ms

- Adding 16777216 quads: 29252.079ms
* Memory usage for quads: 673MB
- Finding all 16777216 quads 1048576 times: 25739.851ms
```

And the benchmarks for this branch can be in the region of:

```
$ node N3Store-perf.js
N3Store performance test
- Adding 16777216 triples to the default graph: 21008.823ms
* Memory usage for triples: 719MB
- Finding all 16777216 triples in the default graph 65536 times (0 variables): 39437.696ms
- Finding all 16777216 triples in the default graph 131072 times (1 variable): 4961.082ms
- Finding all 16777216 triples in the default graph 196608 times (2 variables): 7438.038ms

- Adding 16777216 quads: 27909.561ms
* Memory usage for quads: 799MB
- Finding all 16777216 quads 1048576 times: 16721.452ms
```

Hmmm. Curious indeed.

The problem function in this new experimental code is `_indexSomeGivenKey0` (called for '2 variables', above). Regarding the voodoo trick: my benchmarks seem to show that it doesn't matter whether I use the `Object.keys` or `this._entities` here.

- I get very inconsistent benchmark times.
- Partly I think this may be due to my laptop turbo-boosting or throttling. Don't know. It's not the best machine to benchmark on really because of this.
- Partly I think it may be because the benchmark is actually timing a large chunk of work compared to my previous optimisation experience?
- Partly I think it may be because it's an interpreted language. But I am biased, being much more familiar with compiled languages.
- It's so ridiculously fast on the other methods/permutations that I'm beginning to think we've definitely hit a weird edge case in V8 (take a look at `_indexSomeGivenKey0`... it couldn't do any less - except for not having a callback if we were doing `find`, I guess. But seriously?) Maybe the Chrome team would be interested?
- Apologies in advance for all the commented-out dead code
- Some of the code is plain ugly - and no apologies could really cover that. 

Anyhow, make of it what you will. (Good luck)

— Have you perhaps considered implementing the index lookups in asm.js? <gets coat and runs>