### PR TITLE
Added 'use strict' directive

### DIFF
--- a/N3.js
+++ b/N3.js
@@ -1,3 +1,4 @@
+"use strict";
 // Replace local require by a lazy loader
 var globalRequire = require;
 require = function () {};

--- a/lib/N3Lexer.js
+++ b/lib/N3Lexer.js
@@ -1,3 +1,4 @@
+"use strict";
 // **N3Lexer** tokenizes N3 documents.
 var fromCharCode = String.fromCharCode;
 var immediately = typeof setImmediate === 'function' ? setImmediate :

--- a/lib/N3Parser.js
+++ b/lib/N3Parser.js
@@ -1,3 +1,4 @@
+"use strict";
 // **N3Parser** parses N3 documents.
 var N3Lexer = require('./N3Lexer');
 

--- a/lib/N3Store.js
+++ b/lib/N3Store.js
@@ -1,3 +1,4 @@
+"use strict";
 // **N3Store** objects store N3 triples by graph in memory.
 
 var expandPrefixedName = require('./N3Util').expandPrefixedName;

--- a/lib/N3StreamParser.js
+++ b/lib/N3StreamParser.js
@@ -1,3 +1,4 @@
+"use strict";
 // **N3StreamParser** parses an N3 stream into a triple stream.
 var Transform = require('stream').Transform,
     util = require('util'),

--- a/lib/N3StreamWriter.js
+++ b/lib/N3StreamWriter.js
@@ -1,3 +1,4 @@
+"use strict";
 // **N3StreamWriter** serializes a triple stream into an N3 stream.
 var Transform = require('stream').Transform,
     util = require('util'),

--- a/lib/N3Util.js
+++ b/lib/N3Util.js
@@ -1,3 +1,4 @@
+"use strict";
 // **N3Util** provides N3 utility functions.
 
 var Xsd = 'http://www.w3.org/2001/XMLSchema#';

--- a/lib/N3Writer.js
+++ b/lib/N3Writer.js
@@ -1,3 +1,4 @@
+"use strict";
 // **N3Writer** writes N3 documents.
 
 // Matches a literal as represented in memory by the N3 library


### PR DESCRIPTION
This patch set adds `"use strict";` to the top of every file (except perf and tests).

I believe strict mode has numerous advantages, including making some aspects of development more pleasant.

All tests still pass. 

Nothing else needed changing (which is not always the case when adding strict mode to existing codebases!)