### PR TITLE
added simple toString serialization feature and associated tests

### DIFF
--- a/lib/N3Writer.js
+++ b/lib/N3Writer.js
@@ -98,10 +98,7 @@ N3Writer.prototype = {
     delete this._prefixMatch;
     // Write the triple
     try {
-      this._write(this._encodeIriOrBlankNode(subject) + ' ' +
-                  this._encodeIriOrBlankNode(predicate) + ' ' +
-                  this._encodeObject(object) +
-                  (graph ? ' ' + this._encodeIriOrBlankNode(graph) + '.\n' : '.\n'), done);
+      this._write(this.tripleToString(subject, predicate, object, graph), done);
     }
     catch (error) { done && done(error); }
   },

--- a/lib/N3Writer.js
+++ b/lib/N3Writer.js
@@ -106,6 +106,24 @@ N3Writer.prototype = {
     catch (error) { done && done(error); }
   },
 
+  // ### `tripleToString` serialize a triple or quad as a string
+  tripleToString: function (subject, predicate, object, graph) {
+    return  this._encodeIriOrBlankNode(subject) + ' ' +
+            this._encodeIriOrBlankNode(predicate) + ' ' +
+            this._encodeObject(object) +
+            (graph ? ' ' + this._encodeIriOrBlankNode(graph) + '.\n' : '.\n');
+  },
+
+  // ### `triplesToString` serialize an array of triples or quads as a string
+  triplesToString: function (array) {
+    var string = '';
+    for (var i = 0; i < array.length; i++) {
+      var triple = array[i];
+      string += this.tripleToString(triple.subject, triple.predicate, triple.object, triple.graph);
+    }
+    return string;
+  },
+
   // ### `_encodeIriOrBlankNode` represents an IRI or blank node
   _encodeIriOrBlankNode: function (entity) {
     // A blank node or list is represented as-is

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -502,6 +502,18 @@ describe('N3Writer', function () {
       });
     });
 
+    it('should serialize a simple triple like N-Triples mode', function () {
+      var writer = N3Writer();
+      writer.tripleToString('a', 'b', 'c').should.equal('<a> <b> <c>.\n');
+    });
+
+    it('should serialize a simple triple array like N-Triples mode', function () {
+      var writer = N3Writer();
+      var triples = [{ subject: 'a', predicate: 'b', object: 'c' },
+                      { subject: 'd', predicate: 'e', object: 'f' }];
+      writer.triplesToString(triples).should.equal('<a> <b> <c>.\n<d> <e> <f>.\n');
+    });
+
     it('should not write an invalid literal in N-Triples mode', function (done) {
       var writer = N3Writer({ format: 'N-Triples' });
       writer.addTriple('a', 'b', '"c', function (error) {
@@ -509,6 +521,12 @@ describe('N3Writer', function () {
         error.should.have.property('message', 'Invalid literal: "c');
         done();
       });
+    });
+
+    it('should not serialize an invalid literal like in N-Triples mode', function () {
+      var writer = N3Writer();
+      function test() { writer.tripleToString('a', 'b', '"c'); }
+      test.should.throw(Error, 'Invalid literal: "c');
     });
 
     it('should write simple quads in N-Quads mode', function (done) {
@@ -521,13 +539,24 @@ describe('N3Writer', function () {
       });
     });
 
+    it('should serialize a simple quad like N-Quads mode', function () {
+      var writer = N3Writer();
+      writer.tripleToString('a', 'b', 'c', 'g').should.equal('<a> <b> <c> <g>.\n');
+    });
+
     it('should not write an invalid literal in N-Quads mode', function (done) {
-      var writer = N3Writer({ format: 'N-Triples' });
-      writer.addTriple('a', 'b', '"c', function (error) {
+      var writer = N3Writer({ format: 'N-Quads' });
+      writer.addTriple('a', 'b', '"c', 'g', function (error) {
         error.should.be.an.instanceof(Error);
         error.should.have.property('message', 'Invalid literal: "c');
         done();
       });
+    });
+
+    it('should not serialize an invalid literal like in N-Quads mode', function () {
+      var writer = N3Writer();
+      function test() { writer.tripleToString('a', 'b', '"c', 'g'); }
+      test.should.throw(Error, 'Invalid literal: "c');
     });
 
     it('should end when the end option is not set', function (done) {


### PR DESCRIPTION
It would be really helpful to have a quick, simple and synchronous way to get the store's content to string. So I added 2 exposed functions in the Writer, tripleToString and triplesToString (do change the names, I was lacking inspiration there).
tripleToString is almost the same as _writeTripleLine, it's copy pasted except it directly returns a string. triplesToString calls tripleToString on an array.

I added 5 necessary tests and corrected another one.

There's a possibility of refactoring _writeTripleLine by making it call tripleToString, but I didn't touch it.

Lint and tests passed.