### PR TITLE
Stream parser may fail on literals that are doubles

### DIFF
--- a/test/N3StreamParser-test.js
+++ b/test/N3StreamParser-test.js
@@ -27,6 +27,12 @@ describe('N3StreamParser', function () {
 
     it('parses two triples', shouldParse(['<a> <b>', ' <c>. <d> <e> ', '<f>.'], 2));
 
+    it.skip('should parse double values that are split accross chunks in the stream', function (done) {
+      // this is the same as creating a read-stream from a file, with this one triple, where the
+      // highWaterMark of the readstream is set to 2.
+      shouldParse('<sub> <pred> 11.2 .'.match(/.{1,2}/g), 1)(done);
+    });
+
     it("doesn't parse an invalid stream",
       shouldNotParse(['z.'], 'Unexpected "z." on line 1.'));
 


### PR DESCRIPTION
Here's a bug report, disguised as a PR.

On files that contain double values, the stream parser _sometimes_ fails. Specifically, it fails when one of the chunks that the parser receives ends in the `.` separator of a double value. The parser incorrectly sees that as an end-of-statement, and tries to parse the next chunk as a new statement.

Take for example this ttl file:
```
<sub> <pred> 11.2 .
```

Parsing synchronously works:
```
const fs = require('fs')
var parser = require('./N3').Parser();
parser.parse(fs.readFileSync('./test.ttl', 'utf-8'),
             function (e, triples) {
               if (e) console.log('Synced parsing error', e)
             });

```

Parsing asynchronously does not (setting highWaterMark to 2, for testing purposes):
```
const fs = require('fs')
var N3StreamParser = require('./N3').StreamParser;
fs.createReadStream('./test.ttl', {highWaterMark: 2})
  .pipe(new N3StreamParser())
  .on('data', function(){})
  .on('error', function(e){console.error('Streamed parsing error', e)})
```

This PR adds a unit test to the stream-parser test-suite that replicates this behaviour.