### PR TITLE
change conflicting variable name in Writer

### DIFF
--- a/lib/N3Writer.js
+++ b/lib/N3Writer.js
@@ -10,7 +10,7 @@ var RDF_PREFIX = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
 // Characters in literals that require escaping
 var escape    = /["\\\t\n\r\b\f\u0000-\u0019\ud800-\udbff]/,
     escapeAll = /["\\\t\n\r\b\f\u0000-\u0019]|[\ud800-\udbff][\udc00-\udfff]/g,
-    escapeReplacements = {
+    turtleEscapes = {
       '\\': '\\\\', '"': '\\"', '\t': '\\t',
       '\n': '\\n', '\r': '\\r', '\b': '\\b', '\f': '\\f',
     };
@@ -316,7 +316,7 @@ N3Writer.prototype = {
 // Replaces a character by its escaped version
 function characterReplacer(character) {
   // Replace a single character by its escaped version
-  var result = escapeReplacements[character];
+  var result = turtleEscapes[character];
   if (result === undefined) {
     // Replace a single character with its 4-bit unicode escape sequence
     if (character.length === 1) {


### PR DESCRIPTION
This simple [HTML interface using rawgit](https://jsfiddle.net/ericP/2anpxbrx/1/) gets an error (hit [Parse] to see it) with any literal with `[\r\n\t\b]` in it because the variable `escapeReplacements` appears in [N3Lexer](https://github.com/RubenVerborgh/N3.js/blob/master/lib/N3Lexer.js#L9) and [N3Writer](https://github.com/RubenVerborgh/N3.js/blob/master/lib/N3Writer.js#L13). Renaming it to `turtleEscapes` in `N3Writer` eliminates this error as seen in this [HTML interface using this PR](https://jsfiddle.net/ericP/r77ye4wL/).