### PR TITLE
N3Writer: Support literals with spec-conformant languages

### DIFF
--- a/lib/N3Writer.js
+++ b/lib/N3Writer.js
@@ -1,7 +1,7 @@
 // **N3Writer** writes N3 documents.
 
 // Matches a literal as represented in memory by the N3 library
-var N3LiteralMatcher = /^"([^]*)"(?:\^\^(.+)|@([\-a-z]+))?$/i;
+var N3LiteralMatcher = /^"([^]*)"(?:\^\^(.+)|@([a-z]+(?:-[a-z0-9]+)*))?$/i;
 
 // rdf:type predicate (for 'a' abbreviation)
 var RDF_PREFIX = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',

--- a/test/N3Writer-test.js
+++ b/test/N3Writer-test.js
@@ -67,6 +67,11 @@ describe('N3Writer', function () {
       shouldSerialize(['a', 'b', '"cde"@en-us'],
                       '<a> <b> "cde"@en-us.\n'));
 
+    // e.g. http://vocab.getty.edu/aat/300264727.ttl
+    it('should serialize a literal with an artificial language',
+       shouldSerialize(['a', 'b', '"cde"@qqq-002'],
+                        '<a> <b> "cde"@qqq-002.\n'));
+
     it('should serialize a literal containing a single quote',
       shouldSerialize(['a', 'b', '"c\'de"'],
                       '<a> <b> "c\'de".\n'));


### PR DESCRIPTION
While processing an LOD export of the [Getty's Art & Architecture Thesaurus (AAT)](http://www.getty.edu/research/tools/vocabularies/aat/), I ran into an issue with literals accompanied by language codes that appear to be spec-compliant but are not supported by `N3Writer`.

Please review this fix and consider merging. Thanks!